### PR TITLE
add LMatrix

### DIFF
--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -4,7 +4,8 @@ using StaticArrays
 
 include("slvector.jl")
 include("lvector.jl")
+include("lmatrix.jl")
 
-export SLVector, LVector, @SLVector, @LVector
+export SLVector, LVector, LMatrix, @SLVector, @LVector, @LMatrix
 
 end # module

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -6,6 +6,6 @@ include("slvector.jl")
 include("lvector.jl")
 include("lmatrix.jl")
 
-export SLVector, LVector, LMatrix, @SLVector, @LVector, @LMatrix
+export SLVector, LVector, SLMatrix, LMatrix, @SLVector, @LVector, @SLMatrix, @LMatrix
 
 end # module

--- a/src/lmatrix.jl
+++ b/src/lmatrix.jl
@@ -1,0 +1,111 @@
+struct LMatrix{T,A <: AbstractMatrix{T},Syms1,Syms2} <: AbstractMatrix{T}
+    __x::A
+end
+
+struct LMatrixPartial{Sym1,LM <: LMatrix}
+    __m::LM
+end
+
+Base.size(x::LMatrix) = size(getfield(x,:__x))
+@inline Base.getindex(x::LMatrix,i...) = getfield(x,:__x)[i...]
+@inline Base.setindex!(x::LMatrix,y,i...) = getfield(x,:__x)[i...] = y
+
+Base.propertynames(::LMatrix{T,A,Syms1,Syms2}) where {T,A,Syms1,Syms2} = Syms1, Syms2
+symnames(::Type{LMatrix{T,A,Syms1,Syms2}}, dim) where {T,A,Syms1,Syms2} = (Syms1, Syms2)[dim]
+
+@inline function Base.getproperty(x::LMatrix,s::Symbol)
+    if s == :__x
+        return getfield(x,:__x)
+    end
+    LMatrixPartial{Val{s},typeof(x)}(x)
+end
+
+@inline function Base.getproperty(p::LMatrixPartial{Val{s1}},s2::Symbol) where s1
+    if s2 == :__m
+        return getfield(p,:__m)
+    end
+    p.__m[Val(s1), Val(s2)]
+end
+
+
+@inline function Base.setproperty!(x::LMatrix,s::Symbol,y)
+    if s == :__x
+        return setfield!(x,:__x,y)
+    end
+    x[s,:] .= y
+end
+
+@inline function Base.setproperty!(p::LMatrixPartial{Val{s1}},s2::Symbol,y) where s1
+    p.__m[Val(s1), Val(s2)] = y
+end
+
+@inline Base.getindex(x::LMatrix,s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))
+@inline Base.getindex(x::LMatrix,i1,s2::Symbol) = getindex(x,i1,Val(s2))
+@inline Base.getindex(x::LMatrix,s1::Symbol,i2) = getindex(x,Val(s1),i2)
+
+@inline @generated function Base.getindex(x::LMatrix,::Val{s1},::Val{s2}) where {s1, s2}
+    idx1 = findfirst(y->y==s1,symnames(x,1))
+    idx2 = findfirst(y->y==s2,symnames(x,2))
+    :(x.__x[$idx1, $idx2])
+end
+
+@inline @generated function Base.getindex(x::LMatrix,i1,::Val{s2}) where s2
+    idx2 = findfirst(y->y==s2,symnames(x,2))
+    :(x.__x[i1, $idx2])
+end
+
+@inline @generated function Base.getindex(x::LMatrix,::Val{s1},i2) where s1
+    idx1 = findfirst(y->y==s1,symnames(x,1))
+    :(x.__x[$idx1, i2])
+end
+
+@inline Base.setindex!(x::LMatrix,y,s1::Symbol,s2::Symbol) = setindex!(x,y,Val(s1),Val(s2))
+@inline Base.setindex!(x::LMatrix,y,s1::Symbol,i2) = setindex!(x,y,Val(s1),i2)
+@inline Base.setindex!(x::LMatrix,y,i1,s2::Symbol) = setindex!(x,y,i1,Val(s2))
+
+@inline @generated function Base.setindex!(x::LMatrix,y,::Val{s1},::Val{s2}) where {s1, s2}
+    idx1 = findfirst(y->y==s1,symnames(x,1))
+    idx2 = findfirst(y->y==s2,symnames(x,2))
+    :(x.__x[$idx1, $idx2] = y)
+end
+
+@inline @generated function Base.setindex!(x::LMatrix,y,::Val{s1},i2) where s1
+    idx1 = findfirst(y->y==s1,symnames(x,1))
+    :(x.__x[$idx1, i2] = y)
+end
+
+@inline @generated function Base.setindex!(x::LMatrix,y,i1,::Val{s2}) where s2
+    idx2 = findfirst(y->y==s2,symnames(x,2))
+    :(x.__x[i1, $idx2] = y)
+end
+
+
+function Base.similar(x::LMatrix,::Type{S},dims::NTuple{N,Int}) where {S,N}
+    typeof(x)(similar(x.__x,S,dims))
+end
+
+"""
+    @LMatrix Type Names
+    @LMatrix Type Names Values
+
+Creates an `LMatrix` with names determined from the `Names`
+vector and values determined from the `Values` vector (if no values are provided,
+it defaults to not setting the values to zero). All of the values are converted
+to the type of the `Type` input.
+
+For example:
+
+    a = @LMatrix Float64 [a,b,c] [x,y,z]
+    b = @LMatrix [1,2,3] [a,b,c] [x,y,z]
+"""
+macro LMatrix(vals,syms1,syms2)
+    if typeof(vals) <: Symbol
+        return quote
+            LMatrix{$vals,Matrix{$vals},$syms1,$syms2}(Matrix(undef,length($syms1),length($syms1)))
+        end
+    else
+        return quote
+            LMatrix{eltype($vals),typeof($vals),$syms1,$syms2}($vals)
+        end
+    end
+end

--- a/src/lmatrix.jl
+++ b/src/lmatrix.jl
@@ -13,11 +13,16 @@ struct LMatrixPartial{Sym1,M <: AbstractLMatrix}
 end
 
 Base.size(x::AbstractLMatrix) = size(getfield(x,:__x))
-@inline Base.getindex(x::AbstractLMatrix,i...) = getfield(x,:__x)[i...]
-@inline Base.setindex!(x::AbstractLMatrix,y,i...) = getfield(x,:__x)[i...] = y
-
 Base.propertynames(::AbstractLMatrix{T,A,Syms1,Syms2}) where {T,A,Syms1,Syms2} = Syms1, Syms2
 symnames(::Type{X}, dim) where X <: AbstractLMatrix{T,A,Syms1,Syms2} where {T,A,Syms1,Syms2} = (Syms1, Syms2)[dim]
+
+@inline function Base.getproperty(p::LMatrixPartial{Val{s1}},s2::Symbol) where s1
+    getfield(p, :__m)[Val(s1), Val(s2)]
+end
+
+@inline function Base.setproperty!(p::LMatrixPartial{Val{s1}},s2::Symbol,y) where s1
+    getfield(p, :__m)[Val(s1), Val(s2)] = y
+end
 
 @inline function Base.getproperty(x::AbstractLMatrix,s::Symbol)
     if s == :__x
@@ -26,22 +31,14 @@ symnames(::Type{X}, dim) where X <: AbstractLMatrix{T,A,Syms1,Syms2} where {T,A,
     LMatrixPartial{Val{s},typeof(x)}(x)
 end
 
-@inline function Base.getproperty(p::LMatrixPartial{Val{s1}},s2::Symbol) where s1
-    getfield(p, :__m)[Val(s1), Val(s2)]
-end
-
-
 @inline function Base.setproperty!(x::AbstractLMatrix,s::Symbol,y)
     if s == :__x
         return setfield!(x,:__x,y)
     end
-    x[s,:] .= y
+    x[s,:] = y
 end
 
-@inline function Base.setproperty!(p::LMatrixPartial{Val{s1}},s2::Symbol,y) where s1
-    getfield(p, :__m)[Val(s1), Val(s2)] = y
-end
-
+@inline Base.getindex(x::AbstractLMatrix,i...) = getfield(x,:__x)[i...]
 @inline Base.getindex(x::AbstractLMatrix,s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))
 @inline Base.getindex(x::AbstractLMatrix,i1,s2::Symbol) = getindex(x,i1,Val(s2))
 @inline Base.getindex(x::AbstractLMatrix,s1::Symbol,i2) = getindex(x,Val(s1),i2)
@@ -62,6 +59,7 @@ end
     :(x.__x[$idx1, i2])
 end
 
+@inline Base.setindex!(x::AbstractLMatrix,y,i...) = getfield(x,:__x)[i...] = y
 @inline Base.setindex!(x::AbstractLMatrix,y,s1::Symbol,s2::Symbol) = setindex!(x,y,Val(s1),Val(s2))
 @inline Base.setindex!(x::AbstractLMatrix,y,s1::Symbol,i2) = setindex!(x,y,Val(s1),i2)
 @inline Base.setindex!(x::AbstractLMatrix,y,i1,s2::Symbol) = setindex!(x,y,i1,Val(s2))

--- a/src/lmatrix.jl
+++ b/src/lmatrix.jl
@@ -1,19 +1,25 @@
-struct LMatrix{T,A <: AbstractMatrix{T},Syms1,Syms2} <: AbstractMatrix{T}
+abstract type AbstractLMatrix{T,A,Syms1,Syms2} <: AbstractMatrix{T} end
+
+struct LMatrix{T,A <: AbstractMatrix{T},Syms1,Syms2} <: AbstractLMatrix{T,A,Syms1,Syms2}
     __x::A
 end
 
-struct LMatrixPartial{Sym1,LM <: LMatrix}
-    __m::LM
+struct SLMatrix{T,A <: AbstractMatrix{T},Syms1,Syms2} <: AbstractLMatrix{T,A,Syms1,Syms2}
+    __x::A
 end
 
-Base.size(x::LMatrix) = size(getfield(x,:__x))
-@inline Base.getindex(x::LMatrix,i...) = getfield(x,:__x)[i...]
-@inline Base.setindex!(x::LMatrix,y,i...) = getfield(x,:__x)[i...] = y
+struct LMatrixPartial{Sym1,M <: AbstractLMatrix}
+    __m::M
+end
 
-Base.propertynames(::LMatrix{T,A,Syms1,Syms2}) where {T,A,Syms1,Syms2} = Syms1, Syms2
-symnames(::Type{LMatrix{T,A,Syms1,Syms2}}, dim) where {T,A,Syms1,Syms2} = (Syms1, Syms2)[dim]
+Base.size(x::AbstractLMatrix) = size(getfield(x,:__x))
+@inline Base.getindex(x::AbstractLMatrix,i...) = getfield(x,:__x)[i...]
+@inline Base.setindex!(x::AbstractLMatrix,y,i...) = getfield(x,:__x)[i...] = y
 
-@inline function Base.getproperty(x::LMatrix,s::Symbol)
+Base.propertynames(::AbstractLMatrix{T,A,Syms1,Syms2}) where {T,A,Syms1,Syms2} = Syms1, Syms2
+symnames(::Type{X}, dim) where X <: AbstractLMatrix{T,A,Syms1,Syms2} where {T,A,Syms1,Syms2} = (Syms1, Syms2)[dim]
+
+@inline function Base.getproperty(x::AbstractLMatrix,s::Symbol)
     if s == :__x
         return getfield(x,:__x)
     end
@@ -28,7 +34,7 @@ end
 end
 
 
-@inline function Base.setproperty!(x::LMatrix,s::Symbol,y)
+@inline function Base.setproperty!(x::AbstractLMatrix,s::Symbol,y)
     if s == :__x
         return setfield!(x,:__x,y)
     end
@@ -39,64 +45,82 @@ end
     p.__m[Val(s1), Val(s2)] = y
 end
 
-@inline Base.getindex(x::LMatrix,s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))
-@inline Base.getindex(x::LMatrix,i1,s2::Symbol) = getindex(x,i1,Val(s2))
-@inline Base.getindex(x::LMatrix,s1::Symbol,i2) = getindex(x,Val(s1),i2)
+@inline Base.getindex(x::AbstractLMatrix,s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))
+@inline Base.getindex(x::AbstractLMatrix,i1,s2::Symbol) = getindex(x,i1,Val(s2))
+@inline Base.getindex(x::AbstractLMatrix,s1::Symbol,i2) = getindex(x,Val(s1),i2)
 
-@inline @generated function Base.getindex(x::LMatrix,::Val{s1},::Val{s2}) where {s1, s2}
+@inline @generated function Base.getindex(x::AbstractLMatrix,::Val{s1},::Val{s2}) where {s1, s2}
     idx1 = findfirst(y->y==s1,symnames(x,1))
     idx2 = findfirst(y->y==s2,symnames(x,2))
     :(x.__x[$idx1, $idx2])
 end
 
-@inline @generated function Base.getindex(x::LMatrix,i1,::Val{s2}) where s2
+@inline @generated function Base.getindex(x::AbstractLMatrix,i1,::Val{s2}) where s2
     idx2 = findfirst(y->y==s2,symnames(x,2))
     :(x.__x[i1, $idx2])
 end
 
-@inline @generated function Base.getindex(x::LMatrix,::Val{s1},i2) where s1
+@inline @generated function Base.getindex(x::AbstractLMatrix,::Val{s1},i2) where s1
     idx1 = findfirst(y->y==s1,symnames(x,1))
     :(x.__x[$idx1, i2])
 end
 
-@inline Base.setindex!(x::LMatrix,y,s1::Symbol,s2::Symbol) = setindex!(x,y,Val(s1),Val(s2))
-@inline Base.setindex!(x::LMatrix,y,s1::Symbol,i2) = setindex!(x,y,Val(s1),i2)
-@inline Base.setindex!(x::LMatrix,y,i1,s2::Symbol) = setindex!(x,y,i1,Val(s2))
+@inline Base.setindex!(x::AbstractLMatrix,y,s1::Symbol,s2::Symbol) = setindex!(x,y,Val(s1),Val(s2))
+@inline Base.setindex!(x::AbstractLMatrix,y,s1::Symbol,i2) = setindex!(x,y,Val(s1),i2)
+@inline Base.setindex!(x::AbstractLMatrix,y,i1,s2::Symbol) = setindex!(x,y,i1,Val(s2))
 
-@inline @generated function Base.setindex!(x::LMatrix,y,::Val{s1},::Val{s2}) where {s1, s2}
+@inline @generated function Base.setindex!(x::AbstractLMatrix,y,::Val{s1},::Val{s2}) where {s1, s2}
     idx1 = findfirst(y->y==s1,symnames(x,1))
     idx2 = findfirst(y->y==s2,symnames(x,2))
     :(x.__x[$idx1, $idx2] = y)
 end
 
-@inline @generated function Base.setindex!(x::LMatrix,y,::Val{s1},i2) where s1
+@inline @generated function Base.setindex!(x::AbstractLMatrix,y,::Val{s1},i2) where s1
     idx1 = findfirst(y->y==s1,symnames(x,1))
     :(x.__x[$idx1, i2] = y)
 end
 
-@inline @generated function Base.setindex!(x::LMatrix,y,i1,::Val{s2}) where s2
+@inline @generated function Base.setindex!(x::AbstractLMatrix,y,i1,::Val{s2}) where s2
     idx2 = findfirst(y->y==s2,symnames(x,2))
     :(x.__x[i1, $idx2] = y)
 end
 
 
-function Base.similar(x::LMatrix,::Type{S},dims::NTuple{N,Int}) where {S,N}
+function Base.similar(x::AbstractLMatrix,::Type{S},dims::NTuple{N,Int}) where {S,N}
     typeof(x)(similar(x.__x,S,dims))
 end
 
-"""
-    @LMatrix Type Names
-    @LMatrix Type Names Values
 
-Creates an `LMatrix` with names determined from the `Names`
-vector and values determined from the `Values` vector (if no values are provided,
+"""
+    @SLMatrix Type Values Names1 Names2
+
+Creates a static `SLMatrix` with names determined from the `Names1` and `Names2`
+vectors and values determined from the `Values` vector.
+
+For example:
+
+    a = @SLMatrix [1,2,3] [:a,:b,:c] [:x,:y,:z]
+"""
+macro SLMatrix(vals,syms1,syms2)
+    quote
+        smatrix = SMatrix{size($vals)...}($vals)
+        SLMatrix{eltype(smatrix),typeof(smatrix),$syms1,$syms2}(smatrix)
+    end
+end
+
+"""
+    @LMatrix Type Names1 Names2
+    @LMatrix Values Names1 Names2
+
+Creates an `LMatrix` with names determined from the `Names1` and `Names2`
+vectors and values determined from the `Values` vector (if no values are provided,
 it defaults to not setting the values to zero). All of the values are converted
 to the type of the `Type` input.
 
 For example:
 
-    a = @LMatrix Float64 [a,b,c] [x,y,z]
-    b = @LMatrix [1,2,3] [a,b,c] [x,y,z]
+    a = @LMatrix Float64 [:a,:b,:c] [:x,:y,:z]
+    b = @LMatrix [1,2,3] [:a,:b,:c] [:x,:y,:z]
 """
 macro LMatrix(vals,syms1,syms2)
     if typeof(vals) <: Symbol

--- a/src/lmatrix.jl
+++ b/src/lmatrix.jl
@@ -27,10 +27,7 @@ symnames(::Type{X}, dim) where X <: AbstractLMatrix{T,A,Syms1,Syms2} where {T,A,
 end
 
 @inline function Base.getproperty(p::LMatrixPartial{Val{s1}},s2::Symbol) where s1
-    if s2 == :__m
-        return getfield(p,:__m)
-    end
-    p.__m[Val(s1), Val(s2)]
+    getfield(p, :__m)[Val(s1), Val(s2)]
 end
 
 
@@ -42,7 +39,7 @@ end
 end
 
 @inline function Base.setproperty!(p::LMatrixPartial{Val{s1}},s2::Symbol,y) where s1
-    p.__m[Val(s1), Val(s2)] = y
+    getfield(p, :__m)[Val(s1), Val(s2)] = y
 end
 
 @inline Base.getindex(x::AbstractLMatrix,s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))

--- a/src/slvector.jl
+++ b/src/slvector.jl
@@ -3,7 +3,7 @@ abstract type SLVector{N,T} <: FieldVector{N,T} end
 # SLVector Macro
 
 """
-    @SLVector TypeName ElementType Names
+t   @SLVector TypeName ElementType Names
 
 Creates a static vector type with name TypeName and  eltype ElementType
 with names determined from the `Names`.

--- a/test/lmatrix.jl
+++ b/test/lmatrix.jl
@@ -1,4 +1,4 @@
-using Revise, LabelledArrays, Test, InteractiveUtils
+using LabelledArrays, Test, InteractiveUtils
 
 x = @LMatrix [1.0 2.0; 3.0 4.0] (:a,:b) (:x,:y)
 
@@ -25,8 +25,8 @@ h(x) = x.a.x
 @inferred getindex(x,Val(:a),Val(:x))
 @code_warntype g(x)
 @inferred g(x)
-# @code_warntype h(x)
-# @inferred h(x)
+@code_warntype h(x)
+@inferred h(x)
 
 
 f2(x, y) = x[1,1] = y
@@ -65,3 +65,5 @@ end
 @inferred getindex(x,Val(:a),Val(:x))
 @code_warntype g(x)
 @inferred g(x)
+@code_warntype h(x)
+@inferred h(x)

--- a/test/lmatrix.jl
+++ b/test/lmatrix.jl
@@ -1,0 +1,50 @@
+using LabelledArrays, Test, InteractiveUtils
+
+x = @LMatrix [1.0 2.0; 3.0 4.0] (:a,:b) (:x,:y)
+
+syms1 = (:a,:b)
+syms2 = (:x,:y)
+
+for (i,s) in enumerate(syms1)
+    @show i,s
+    @test x[i,:x] == x[s,:x]
+end
+
+x[Val(:a), Val(:x)]
+
+f(x) = x[1,1]
+g(x) = x[:a,:x]
+h(x) = x.a.x
+
+@time f(x)
+@time f(x)
+@time g(x)
+@time g(x)
+@time h(x)
+@time h(x)
+
+@code_warntype getindex(x,Val(:a),Val(:x))
+@inferred getindex(x,Val(:a),Val(:x))
+@code_warntype g(x)
+@inferred g(x)
+# @code_warntype h(x)
+# @inferred h(x)
+
+
+f2(x, y) = x[1,1] = y
+g2(x, y) = x[:a,:x] = y
+h2(x, y) = x.a.x = y
+
+g2(x, 6.0)
+@test x[1,1] == 6.0
+h2(x, 7.0)
+@test x[1,1] == 7.0
+
+@time f2(x, 5.0)
+@time g2(x, 5.0)
+@time h2(x, 5.0)
+
+@code_warntype g2(x, 1.0)
+@inferred g2(x, 1.0)
+@code_warntype h2(x, 1.0)
+@inferred h2(x, 1.0)

--- a/test/lmatrix.jl
+++ b/test/lmatrix.jl
@@ -1,5 +1,7 @@
 using LabelledArrays, Test, InteractiveUtils
 
+# Test LMatrix
+
 x = @LMatrix [1.0 2.0; 3.0 4.0] (:a,:b) (:x,:y)
 
 syms1 = (:a,:b)
@@ -38,6 +40,7 @@ g2(x, 6.0)
 h2(x, 7.0)
 @test x[1,1] == 7.0
 
+
 @time f2(x, 5.0)
 @time g2(x, 5.0)
 @time h2(x, 5.0)
@@ -46,6 +49,21 @@ h2(x, 7.0)
 @inferred g2(x, 1.0)
 @code_warntype h2(x, 1.0)
 @inferred h2(x, 1.0)
+
+# Assign to columns 
+
+x[:a,:] = [-1.0, -2.0]
+@test x[1,:] == [-1.0, -2.0]
+
+x.a = [-3.0, -4.0]
+@test x[1,:] == [-3.0, -4.0]
+
+# Broadcasting
+# x[:a,:] .= [-1.0, -2.0]
+# x.a .= [-3.0, -4.0]
+
+
+# Test SLMatrix
 
 x = @SLMatrix [1 2; 3 4] (:a,:b) (:x,:y)
 

--- a/test/lmatrix.jl
+++ b/test/lmatrix.jl
@@ -1,4 +1,4 @@
-using LabelledArrays, Test, InteractiveUtils
+using Revise, LabelledArrays, Test, InteractiveUtils
 
 x = @LMatrix [1.0 2.0; 3.0 4.0] (:a,:b) (:x,:y)
 
@@ -9,8 +9,6 @@ for (i,s) in enumerate(syms1)
     @show i,s
     @test x[i,:x] == x[s,:x]
 end
-
-x[Val(:a), Val(:x)]
 
 f(x) = x[1,1]
 g(x) = x[:a,:x]
@@ -48,3 +46,22 @@ h2(x, 7.0)
 @inferred g2(x, 1.0)
 @code_warntype h2(x, 1.0)
 @inferred h2(x, 1.0)
+
+x = @SLMatrix [1 2; 3 4] (:a,:b) (:x,:y)
+
+for (i,s) in enumerate(syms1)
+    @show i,s
+    @test x[i,:x] == x[s,:x]
+end
+
+@time f(x)
+@time f(x)
+@time g(x)
+@time g(x)
+@time h(x)
+@time h(x)
+
+@code_warntype getindex(x,Val(:a),Val(:x))
+@inferred getindex(x,Val(:a),Val(:x))
+@code_warntype g(x)
+@inferred g(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,6 @@ using Test
 @time @testset "SLVector Macros" begin include("slvectors.jl") end
 #@time @testset "LMArrays" begin include("lmarrays.jl") end
 @time @testset "LVectors" begin include("lvectors.jl") end
+@time @testset "LMatrix" begin include("lmatrix.jl") end
 @time @testset "DiffEq" begin include("diffeq.jl") end
 end


### PR DESCRIPTION
This is a working draft version.

I've set it up to work with both `x.a.b` and `x[:a, :b]` syntax. I'm imagining `SLMatrix` will be identical to `LMatrix`, but converting the passed in array to a StaticArrays `SMatrix`. So most of the code should be shared using a parent abstract type.

There are also probably a few opportunities to refactor this to share some code with `lvector.jl`.

- [x] Working LMatrix
- [x] Working SLMatrix
- [x] Type stable `getproperty`
- [ ] Broadcast to range/colon in both `setindex!` and `setproperty!`
- [ ] Refactor to share code with vectors
- [ ] Generalise for any array dimensions?

Let me know if this all generally makes sense.