### PR TITLE
Rewrite `SLVector` as a subtype of `StaticVector`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 1.0
 StaticArrays
+Reexport

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -1,6 +1,7 @@
 module LabelledArrays
 
-using StaticArrays, LinearAlgebra
+using Reexport, LinearAlgebra
+@reexport using StaticArrays
 
 include("slvector.jl")
 include("lvector.jl")

--- a/src/slvector.jl
+++ b/src/slvector.jl
@@ -1,17 +1,40 @@
-abstract type SLVector{N,T} <: FieldVector{N,T} end
+struct SLVector{N,T,Syms} <: StaticVector{N,T}
+    __x::SVector{N,T} # allow general StaticVector?
+    SLVector{N,T,Syms}(__x::SVector{N,T}) where {N,T,Syms} = new{N,T,Syms}(__x)
+    SLVector{N,T,Syms}(x::NTuple{N,T}) where {N,T,Syms} = new{N,T,Syms}(SVector{N}(x))
+end
 
-# SLVector Macro
+# Implement the StaticVector interface
+@inline Base.getindex(x::SLVector, i::Int) = getfield(x,:__x)[i]
+@inline Base.Tuple(x::SLVector) = Tuple(x.__x)
+function StaticArrays.similar_type(::Type{SLVector{N,T,Syms}}, ::Type{NewElType},
+    ::Size{NewSize}) where {N,T,Syms,NewElType,NewSize}
+    @assert length(NewSize) == 1 && NewSize[1] == N
+    SLVector{N,NewElType,Syms}
+end
+
+# Fast indexing by labels (x.a or x[:a], internally x[Val(:a)])
+Base.propertynames(::SLVector{N,T,Syms}) where {N,T,Syms} = Syms
+symnames(::Type{SLVector{N,T,Syms}}) where {N,T,Syms} = Syms
+@inline function Base.getproperty(x::SLVector,s::Symbol)
+    s == :__x ? getfield(x,:__x) : x[Val(s)]
+end
+@inline Base.getindex(x::SLVector,s::Symbol) = x[Val(s)]
+@inline @generated function Base.getindex(x::SLVector,::Val{s}) where {s}
+    idx = findfirst(==(s),symnames(x))
+    :(x.__x[$idx])
+end
 
 """
-    @SLVector TypeName ElementType Names
+    @SLVector ElementType Names
 
-Creates a static vector type with name TypeName and  eltype ElementType
-with names determined from the `Names`.
+Creates an anonymous function that builds a labelled static vector with eltype
+`ElementType` with names determined from the `Names`.
 
 For example:
 
 ```julia
-@SLVector ABC Float64 [a,b,c]
+ABC = @SLVector Float64 (:a,:b,:c)
 x = ABC(1.0,2.5,3.0)
 x.a == 1.0
 x.b == 2.5
@@ -19,19 +42,10 @@ x.c == x[3]
 ```
 
 """
-macro SLVector(tname,T,_names)
-    names = Symbol.(_names.args)
-    quote
-        struct $(tname) <: SLVector{$(length(names)),$T}
-            $((:($n::$T) for n in names)...)
-            $(tname)($((:($n) for n in names)...)) = new($((:($n) for n in names)...))
-            $(tname)(x::Tuple{Any}) = new(first(x))
+macro SLVector(E,syms)
+    return quote
+        function (vals...,)
+            SLVector{$(length(syms.args)),$(esc(E)),$syms}(vals)
         end
     end
-end
-
-# Fix broadcast https://github.com/JuliaArrays/StaticArrays.jl/issues/314
-function StaticArrays.similar_type(::Type{V}, ::Type{T}, ::Size{N}) where
-                                                        {V<:SLVector,T,N}
-    V
 end

--- a/src/slvector.jl
+++ b/src/slvector.jl
@@ -1,7 +1,7 @@
 struct SLVector{N,T,Syms} <: StaticVector{N,T}
     __x::SVector{N,T} # allow general StaticVector?
-    SLVector{N,T,Syms}(__x::SVector{N,T}) where {N,T,Syms} = new{N,T,Syms}(__x)
-    SLVector{N,T,Syms}(x::NTuple{N,T}) where {N,T,Syms} = new{N,T,Syms}(SVector{N}(x))
+    SLVector{N,T,Syms}(__x::SVector) where {N,T,Syms} = new{N,T,Syms}(T.(__x))
+    SLVector{N,T,Syms}(x::Tuple) where {N,T,Syms} = new{N,T,Syms}(SVector{N}(T.(x)))
 end
 
 # Implement the StaticVector interface

--- a/src/slvector.jl
+++ b/src/slvector.jl
@@ -43,9 +43,7 @@ x.c == x[3]
 
 """
 macro SLVector(E,syms)
-    return quote
-        function (vals...,)
-            SLVector{$(length(syms.args)),$(esc(E)),$syms}(vals)
-        end
+    quote
+        SLVector{$(length(syms.args)),$(esc(E)),$syms}
     end
 end

--- a/test/diffeq.jl
+++ b/test/diffeq.jl
@@ -1,7 +1,7 @@
 using LabelledArrays, OrdinaryDiffEq, Test
 
-@SLVector LorenzVector Float64 [x,y,z]
-@SLVector LorenzParameterVector Float64 [σ,ρ,β]
+LorenzVector = @SLVector Float64 (:x,:y,:z)
+LorenzParameterVector = @SLVector Float64 (:σ,:ρ,:β)
 
 function f(u,p,t)
   x = p.σ*(u.y-u.x)

--- a/test/diffeq.jl
+++ b/test/diffeq.jl
@@ -15,6 +15,8 @@ p = LorenzParameterVector(10.0,28.0,8/3)
 tspan = (0.0,10.0)
 prob = ODEProblem(f,u0,tspan,p)
 sol = solve(prob,Tsit5())
+@test typeof(prob.u0) == eltype(sol.u) == LorenzVector
+@test typeof(prob.p) == LorenzParameterVector
 @test sol[10].x > 0
 
 function iip_f(du,u,p,t)
@@ -32,4 +34,6 @@ prob = ODEProblem(iip_f,u0,tspan,p)
 @test zero(u0) isa LVector
 
 sol = solve(prob,Tsit5())
+@test typeof(prob.u0) == eltype(sol.u) == typeof(u0)
+@test typeof(prob.p) == LorenzParameterVector
 @test sol[10].x > 0

--- a/test/slvectors.jl
+++ b/test/slvectors.jl
@@ -16,11 +16,10 @@ b = ABC(1,2,3)
 
 # Type stability tests
 ABC_fl = @SLVector Float64 (:a, :b, :c)
-b_fl = ABC_fl(1.0, 2.0, 3.0)
-@test similar_type(b, Float64) == typeof(b_fl)
-@test typeof(copy(b)) == typeof(b)
-@test typeof(Float64.(b)) == typeof(b_fl)
-@test typeof(b .+ b) == typeof(b)
-@test typeof(b .+ 1.0) == typeof(b_fl)
-@test typeof(zero(b)) == typeof(b)
+@test similar_type(b, Float64) == ABC_fl
+@test typeof(copy(b)) == ABC
+@test typeof(Float64.(b)) == ABC_fl
+@test typeof(b .+ b) == ABC
+@test typeof(b .+ 1.0) == ABC_fl
+@test typeof(zero(b)) == ABC
 @test similar(b) isa MArray # similar should return a mutable copy

--- a/test/slvectors.jl
+++ b/test/slvectors.jl
@@ -1,7 +1,7 @@
 using LabelledArrays
 using Test
 
-@SLVector ABC Int [a,b,c]
+ABC = @SLVector Int (:a,:b,:c)
 b = ABC(1,2,3)
 
 @test b.a == 1
@@ -12,5 +12,15 @@ b = ABC(1,2,3)
 @test b[3] == b.c
 
 @test_throws UndefVarError fill!(a,1)
-@test typeof(b) <: SLVector{3,Int}
-typeof(b.+b) <: ABC
+@test typeof(b.__x) == SVector{3,Int}
+
+# Type stability tests
+ABC_fl = @SLVector Float64 (:a, :b, :c)
+b_fl = ABC_fl(1.0, 2.0, 3.0)
+@test similar_type(b, Float64) == typeof(b_fl)
+@test typeof(copy(b)) == typeof(b)
+@test typeof(Float64.(b)) == typeof(b_fl)
+@test typeof(b .+ b) == typeof(b)
+@test typeof(b .+ 1.0) == typeof(b_fl)
+@test typeof(zero(b)) == typeof(b)
+@test similar(b) isa MArray # similar should return a mutable copy


### PR DESCRIPTION
https://github.com/JuliaDiffEq/LabelledArrays.jl/pull/18#issuecomment-436278719

For the `@SLVector` macro, I modified @YingboMa's implementation to not return an anonymous constructor-like function but instead the type/constructor itself. This makes code much simpler (e.g. see the new slvectors.jl tests).

`similar(x)` and `AbstractFloat{T}(x)` still returns an unwrapped `MArray`. This is the behavior intended by StaticArrays (https://github.com/JuliaArrays/StaticArrays.jl/blob/master/src/abstractarray.jl#L94). I can probably make it better by defining a `MLVector` type, but for now this isn't really an issue. 