### PR TITLE
Named tuple conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ typed `SLArray` via:
 SVType = @SLVector Float64 (:a,:b,:c)
 ```
 
+Alternatively, you can also construct a static labelled array using the
+`SLVector` constructor by writing out the entries as keyword arguments:
+
+```julia
+julia> SLVector(a=1, b=2, c=3)
+3-element SLArray{Tuple{3},1,(:a, :b, :c),Int64}:
+ 1
+ 2
+ 3
+```
+
+For general N-dimensional labelled arrays, you need to specify the size
+(`Tuple{dim1,dim2,...}`) as the type parameter to the `SLArray` constructor:
+
+```julia
+julia> SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
+2×2 SLArray{Tuple{2,2},2,(:a, :b, :c, :d),Int64}:
+ 1  3
+ 2  4
+```
+
 ## LArrays
 
 The `LArrayz`s are fully mutable arrays with labels. There is no performance
@@ -59,6 +80,22 @@ or using an `@LVector` shorthand:
 ```julia
 A = @LVector Float64 (:a,:b,:c,:d)
 A .= rand(4)
+```
+
+As with `SLArray`, alternative constructors exist that use the keyword argument
+form:
+
+```julia
+julia> LVector(a=1, b=2, c=3)
+3-element LArray{Int64,1,(:a, :b, :c)}:
+ 1
+ 2
+ 3
+
+julia> LArray((2,2); a=1, b=2, c=3, d=4) # need to specify size as first argument
+2×2 LArray{Int64,2,(:a, :b, :c, :d)}:
+ 1  3
+ 2  4
 ```
 
 ## Example: Nice DiffEq Syntax Without A DSL
@@ -115,32 +152,26 @@ Julia's Base has NamedTuples in v0.7+. They are constructed as:
 p = (σ = 10.0,ρ = 28.0,β = 8/3)
 ```
 
-and they support `p[1]` and `p.σ` as well. LabelledArrays provides
-the `LVector` and `SLVector` function for constructing a 1D array
-from a named tuple:
+and they support `p[1]` and `p.σ` as well. The `LVector`, `SLVector`, `LArray`
+and `SLArray` constructors also support named tuples as their arguments:
 
 ```julia
-julia> x = LVector((a=1, b=2)) # LVector(a=1, b=2) also works
+julia> LVector((a=1, b=2))
 2-element LArray{Int64,1,(:a, :b)}:
  1
  2
 
-julia> x_static = SLVector((a=1, b=2)) # SLVector(a=1, b=2) also works
+julia> SLVector((a=1, b=2))
 2-element SLArray{Tuple{2},1,(:a, :b),Int64}:
  1
  2
-```
 
-You can also create N-dimentional arrays from named tuples using
-the `LArray` and `SLArray` constructors, but you need to specify the size:
-
-```julia
-julia> LArray((2,2), (a=1, b=2, c=3, d=4)) # LArray((2,2); a=1, b=2, c=3, d=4)
+julia> LArray((2,2), (a=1, b=2, c=3, d=4))
 2×2 LArray{Int64,2,(:a, :b, :c, :d)}:
  1  3
  2  4
 
-julia> SLArray{Tuple{2,2}}((a=1, b=2, c=3, d=4)) # SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
+julia> SLArray{Tuple{2,2}}((a=1, b=2, c=3, d=4))
 2×2 SLArray{Tuple{2,2},2,(:a, :b, :c, :d),Int64}:
  1  3
  2  4

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ prob = ODEProblem(f,u0,tspan,p)
 sol = solve(prob,Tsit5())
 ```
 
-## Differences from NamedTuples
+## Relation to NamedTuples
 
 Julia's Base has NamedTuples in v0.7+. They are constructed as:
 
@@ -115,13 +115,49 @@ Julia's Base has NamedTuples in v0.7+. They are constructed as:
 p = (σ = 10.0,ρ = 28.0,β = 8/3)
 ```
 
-and they support `p[1]` and `p.σ` as well. However, there are some
-crucial differences between a labelled array and static array.
-But `@SLVector` also differs from a NamedTuple due to how the
-type information is stored. A NamedTuple can have different types
-on each element, while an `@SLVector` can only have one element
-type and has the actions of a static vector. Thus `@SLVector`
-has less element type information, improving compilation speed,
-while giving more vector functionality than a NamedTuple.
-`@LVector` also only has a single element type and, a crucial
-difference, is mutable.
+and they support `p[1]` and `p.σ` as well. LabelledArrays provides
+the `LVector` and `SLVector` function for constructing a 1D array
+from a named tuple:
+
+```julia
+julia> x = LVector((a=1, b=2)) # LVector(a=1, b=2) also works
+2-element LArray{Int64,1,(:a, :b)}:
+ 1
+ 2
+
+julia> x_static = SLVector((a=1, b=2)) # SLVector(a=1, b=2) also works
+2-element SLArray{Tuple{2},1,(:a, :b),Int64}:
+ 1
+ 2
+```
+
+You can also create N-dimentional arrays from named tuples using
+the `LArray` and `SLArray` constructors, but you need to specify the size:
+
+```julia
+julia> LArray((2,2), (a=1, b=2, c=3, d=4)) # LArray((2,2); a=1, b=2, c=3, d=4)
+2×2 LArray{Int64,2,(:a, :b, :c, :d)}:
+ 1  3
+ 2  4
+
+julia> SLArray{Tuple{2,2}}((a=1, b=2, c=3, d=4)) # SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
+2×2 SLArray{Tuple{2,2},2,(:a, :b, :c, :d),Int64}:
+ 1  3
+ 2  4
+```
+
+Converting to a named tuple from a labelled array x is available
+using `convert(NamedTuple, x)`. Furthermore, `pairs(x)`
+creates an iterator that is functionally the same as
+`pairs(convert(NamedTuple, x))`, yielding `:label => x.label`
+for each label of the array.
+
+There are some crucial differences between a labelled array and
+a named tuple. Labelled arrays can have any dimensions while 
+named tuples are always 1D. A named tuple can have different types
+on each element, while an `SLArray` can only have one element
+type and furthermore it has the actions of a static vector.
+As a result `SLArray` has less element type information, which 
+improves compilation speed while giving more vector functionality
+than a NamedTuple. `LArray` also only has a single element type and,
+unlike a named tuple, is mutable.

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -6,6 +6,6 @@ include("slarray.jl")
 include("larray.jl")
 include("display.jl")
 
-export SLArray, LArray, @SLVector, @LArray, @LVector, @SLArray
+export SLArray, LArray, SLVector, LVector, @SLVector, @LArray, @LVector, @SLArray
 
 end # module

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -30,7 +30,8 @@ LVector(;kwargs...) = LVector(kwargs.data)
 
 ## pairs iterator
 Base.pairs(x::LArray{T,N,Syms}) where {T,N,Syms} =
-    (label => getproperty(x, label) for label in Syms)
+    # (label => getproperty(x, label) for label in Syms) # not type stable?
+    (Syms[i] => x[i] for i in 1:length(Syms))
 
 #####################################
 # Array Interface

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -28,6 +28,10 @@ LArray(size::NTuple{S,Int}; kwargs...) where {S} = LArray(size, kwargs.data)
 LVector(tup::NamedTuple) = LArray((length(tup),), tup)
 LVector(;kwargs...) = LVector(kwargs.data)
 
+## pairs iterator
+Base.pairs(x::LArray{T,N,Syms}) where {T,N,Syms} =
+    (label => getproperty(x, label) for label in Syms)
+
 #####################################
 # Array Interface
 #####################################

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -30,6 +30,10 @@ SLArray{Size}(;kwargs...) where {Size} = SLArray{Size}(kwargs.data)
 SLVector(tup::NamedTuple) = SLArray{Tuple{length(tup)}}(tup)
 SLVector(;kwargs...) = SLVector(kwargs.data)
 
+## pairs iterator
+Base.pairs(x::SLArray{S,N,Syms,T}) where {S,N,Syms,T} =
+    (label => getproperty(x, label) for label in Syms)
+
 #####################################
 # StaticArray Interface
 #####################################

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -32,7 +32,8 @@ SLVector(;kwargs...) = SLVector(kwargs.data)
 
 ## pairs iterator
 Base.pairs(x::SLArray{S,N,Syms,T}) where {S,N,Syms,T} =
-    (label => getproperty(x, label) for label in Syms)
+    # (label => getproperty(x, label) for label in Syms) # not type stable?
+    (Syms[i] => x[i] for i in 1:length(Syms))
 
 #####################################
 # StaticArray Interface

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -1,51 +1,71 @@
 using LabelledArrays, Test, InteractiveUtils
 
-x = @LArray [1.0,2.0,3.0] (:a,:b,:c)
-y = @LVector Float64 (:a,:b,:c)
-y .= [1,2,3.]
-@test x == y
+@testset "Basic interface" begin
+    x = @LArray [1.0,2.0,3.0] (:a,:b,:c)
+    y = @LVector Float64 (:a,:b,:c)
+    y .= [1,2,3.]
+    @test x == y
 
-syms = (:a,:b,:c)
+    syms = (:a,:b,:c)
 
-for (i,s) in enumerate(syms)
-    @show i,s
-    @test x[i] == x[s]
+    for (i,s) in enumerate(syms)
+        @show i,s
+        @test x[i] == x[s]
+    end
+
+    x[:a]
+
+    f(x) = x[1]
+    g(x) = x.a
+    @time f(x)
+    @time f(x)
+    @time g(x)
+    @time g(x)
+
+    #@code_warntype x.a
+    #@inferred getindex(x,:a)
+    @code_warntype g(x)
+    @inferred g(x)
+
+    x = @LArray [1,2,3] (:a,:b,:c)
+    @test x .* x isa LArray
+    @test x .+ 1 isa LArray
+    @test x .+ 1. isa LArray
+    z = x .+ ones(Int, 3)
+    @test z isa LArray && eltype(z) === Int
+    z = x .+ ones(Float64, 3)
+    @test z isa LArray && eltype(z) === Float64
+    @test eltype(x .+ 1.) === Float64
+
+    z = @LArray Float64 (2,2) (:a,:b,:c,:d)
+    w = rand(2,2)
+    z .= w
+
+    @test z[:a] == w[1,1]
+    @test z[:b] == w[2,1]
+    @test z[:c] == w[1,2]
+    @test z[:d] == w[2,2]
 end
 
-x[:a]
+@testset "NameTuple conversion" begin
+    x_tup = (a=1, b=2)
+    y_tup = (a=1, b=2, c=3, d=4)
+    x = LVector(a=1, b=2)
+    y = LArray((2,2); a=1, b=2, c=3, d=4)
+    @test convert(NamedTuple, x) == x_tup
+    @test convert(NamedTuple, y) == y_tup
+    @test collect(pairs(x)) == collect(pairs(x_tup))
+    @test collect(pairs(y)) == collect(pairs(y_tup))
 
-f(x) = x[1]
-g(x) = x.a
-@time f(x)
-@time f(x)
-@time g(x)
-@time g(x)
+    @code_warntype LArray((2,2); a=1, b=2, c=3, d=4)
+    @code_warntype convert(NamedTuple, y)
+    @code_warntype collect(pairs(y))
+end
 
-#@code_warntype x.a
-#@inferred getindex(x,:a)
-@code_warntype g(x)
-@inferred g(x)
-
-x = @LArray [1,2,3] (:a,:b,:c)
-@test x .* x isa LArray
-@test x .+ 1 isa LArray
-@test x .+ 1. isa LArray
-z = x .+ ones(Int, 3)
-@test z isa LArray && eltype(z) === Int
-z = x .+ ones(Float64, 3)
-@test z isa LArray && eltype(z) === Float64
-@test eltype(x .+ 1.) === Float64
-
-z = @LArray Float64 (2,2) (:a,:b,:c,:d)
-w = rand(2,2)
-z .= w
-
-@test z[:a] == w[1,1]
-@test z[:b] == w[2,1]
-@test z[:c] == w[1,2]
-@test z[:d] == w[2,2]
-
-t = similar(z, String) # t's elements are uninitialized
-@test_throws UndefRefError t[1]
-copy(t) # should be ok
-deepcopy(t) # should also be ok
+@testset "undef copy" begin
+    z = @LArray Float64 (2,2) (:a,:b,:c,:d)
+    t = similar(z, String) # t's elements are uninitialized
+    @test_throws UndefRefError t[1]
+    copy(t) # should be ok
+    deepcopy(t) # should also be ok
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using StaticArrays
 
 @time begin
-@time @testset "SLArrays Macros" begin include("slarrays.jl") end
+@time @testset "SLArrays" begin include("slarrays.jl") end
 @time @testset "LArrays" begin include("larrays.jl") end
 @time @testset "DiffEq" begin include("diffeq.jl") end
 @time @testset "Display" begin include("display.jl") end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -1,26 +1,43 @@
-using LabelledArrays
-using Test
+using LabelledArrays, StaticArrays
+using Test, InteractiveUtils
 
-ABC = @SLVector (:a,:b,:c)
-b = ABC(1,2,3)
+@testset "Basic interface" begin
+    ABC = @SLVector (:a,:b,:c)
+    b = ABC(1,2,3)
 
-@test b.a == 1
-@test b.b == 2
-@test b.c == 3
-@test b[1] == b.a
-@test b[2] == b.b
-@test b[3] == b.c
+    @test b.a == 1
+    @test b.b == 2
+    @test b.c == 3
+    @test b[1] == b.a
+    @test b[2] == b.b
+    @test b[3] == b.c
 
-@test_throws UndefVarError fill!(a,1)
-@test typeof(b.__x) == SVector{3,Int}
+    @test_throws UndefVarError fill!(a,1)
+    @test typeof(b.__x) == SVector{3,Int}
 
-# Type stability tests
-ABC_fl = @SLVector Float64 (:a, :b, :c)
-ABC_int = @SLVector Int (:a, :b, :c)
-@test similar_type(b, Float64) == ABC_fl
-@test typeof(copy(b)) == ABC_int
-@test typeof(Float64.(b)) == ABC_fl
-@test typeof(b .+ b) == ABC_int
-@test typeof(b .+ 1.0) == ABC_fl
-@test typeof(zero(b)) == ABC_int
-@test similar(b) isa MArray # similar should return a mutable copy
+    # Type stability tests
+    ABC_fl = @SLVector Float64 (:a, :b, :c)
+    ABC_int = @SLVector Int (:a, :b, :c)
+    @test similar_type(b, Float64) == ABC_fl
+    @test typeof(copy(b)) == ABC_int
+    @test typeof(Float64.(b)) == ABC_fl
+    @test typeof(b .+ b) == ABC_int
+    @test typeof(b .+ 1.0) == ABC_fl
+    @test typeof(zero(b)) == ABC_int
+    @test similar(b) isa MArray # similar should return a mutable copy
+end
+
+@testset "NamedTuple conversion" begin
+    x_tup = (a=1, b=2)
+    y_tup = (a=1, b=2, c=3, d=4)
+    x = SLVector(a=1, b=2)
+    y = SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
+    @test convert(NamedTuple, x) == x_tup
+    @test convert(NamedTuple, y) == y_tup
+    @test collect(pairs(x)) == collect(pairs(x_tup))
+    @test collect(pairs(y)) == collect(pairs(y_tup))
+
+    @code_warntype SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
+    @code_warntype convert(NamedTuple, y)
+    @code_warntype collect(pairs(y))
+end


### PR DESCRIPTION
Allows conversion to and from named tuples. 

https://github.com/JuliaDiffEq/LabelledArrays.jl/issues/12#issuecomment-439719837

Not quite sure why `pairs` is not type stable though when defined as

```julia
Base.pairs(x::SLArray{S,N,Syms,T}) where {S,N,Syms,T} =
    (label => getproperty(x, label) for label in Syms) # not type stable?
```

Same for `LArray`. Might have something to do with the generated `getindex` (the current version uses linear indexing instead)? Speaking of which, @ChrisRackauckas can you explain why

```julia
f(x) = x.a
@code_warntype f(x)
``` 

is ok in the tests but not `@code_warntype x.a` directly?