### PR TITLE
Fix inference in SLArray

### DIFF
--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -1,9 +1,9 @@
-struct SLArray{S,N,Syms,T} <: StaticArray{S,T,N}
-  __x::SArray{S,T,N}
+struct SLArray{S,N,L,Syms,T} <: StaticArray{S,T,N}
+  __x::SArray{S,T,N,L}
   #SLArray{Syms}(__x::StaticArray{S,T,N}) where {S,N,Syms,T} = new{S,N,Syms,T}(__x)
-  SLArray{S,N,Syms,T}(__x::SArray) where {S,N,Syms,T} = new{S,N,Syms,T}(T.(__x))
-  SLArray{S,N,Syms}(x::Tuple) where {S,N,Syms} = new{S,N,Syms,eltype(x)}(SArray{S,eltype(x),N}(x))
-  SLArray{S,N,Syms,T}(x::Tuple) where {S,N,Syms,T} = new{S,N,Syms,T}(SArray{S,T,N}(T.(x)))
+  Base.@pure SLArray{S,N,Syms,T}(__x::SArray) where {S,N,Syms,T} = new{S,N,length(__x),Syms,T}(convert.(T,__x))
+  Base.@pure SLArray{S,N,Syms}(x::Tuple) where {S,N,Syms} = new{S,N,ndims(x),Syms,eltype(x)}(SArray{S,eltype(x),N}(x))
+  Base.@pure SLArray{S,N,Syms,T}(x::Tuple) where {S,N,Syms,T} = new{S,N,ndims(x),Syms,T}(SArray{S,T,N}(T.(x)))
 end
 
 #####################################

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -10,7 +10,7 @@ end
 # NamedTuple compatibility
 #####################################
 ## SLArray to named tuple
-function Base.convert(::Type{NamedTuple}, x::SLArray{S,N,Syms,T}) where {S,N,Syms,T}
+function Base.convert(::Type{NamedTuple}, x::SLArray{S,N,L,Syms,T}) where {S,N,L,Syms,T}
   tup = NTuple{length(Syms),T}(x)
   NamedTuple{Syms,typeof(tup)}(tup)
 end
@@ -31,7 +31,7 @@ SLVector(tup::NamedTuple) = SLArray{Tuple{length(tup)}}(tup)
 SLVector(;kwargs...) = SLVector(kwargs.data)
 
 ## pairs iterator
-Base.pairs(x::SLArray{S,N,Syms,T}) where {S,N,Syms,T} =
+Base.pairs(x::SLArray{S,N,L,Syms,T}) where {S,N,L,Syms,T} =
     # (label => getproperty(x, label) for label in Syms) # not type stable?
     (Syms[i] => x[i] for i in 1:length(Syms))
 
@@ -40,14 +40,14 @@ Base.pairs(x::SLArray{S,N,Syms,T}) where {S,N,Syms,T} =
 #####################################
 @inline Base.getindex(x::SLArray, i::Int) = getfield(x,:__x)[i]
 @inline Base.Tuple(x::SLArray) = Tuple(x.__x)
-function StaticArrays.similar_type(::Type{SLArray{S,N,Syms,T}}, ::Type{NewElType},
-    ::Size{NewSize}) where {S,T,N,Syms,NewElType,NewSize}
+function StaticArrays.similar_type(::Type{SLArray{S,N,L,Syms,T}}, ::Type{NewElType},
+    ::Size{NewSize}) where {S,N,L,Syms,T,NewElType,NewSize}
   @assert length(NewSize) == N
   SLArray{S,N,Syms,NewElType}
 end
 
-Base.propertynames(::SLArray{S,N,Syms,T}) where {S,N,T,Syms} = Syms
-symnames(::Type{SLArray{S,N,Syms,T}}) where {S,N,T,Syms} = Syms
+Base.propertynames(::SLArray{S,N,L,Syms,T}) where {S,N,L,Syms,T} = Syms
+symnames(::Type{SLArray{S,N,L,Syms,T}}) where {S,N,L,Syms,T} = Syms
 @inline function Base.getproperty(x::SLArray,s::Symbol)
   s == :__x ? getfield(x,:__x) : x[s]
 end


### PR DESCRIPTION
@andreasnoack noticed that we had an instability here because we were missing a type parameter on the SArray. It looks like `L` is the length of the static array, so this adds that type parameter and computes it. I didn't check inference but `Base.@pure` should be safe on those constructors so at least that should allow the parameters to infer when using `length` to get `L`. 