### PR TITLE
Slice labelled arrays

### DIFF
--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -4,7 +4,11 @@ using LinearAlgebra, StaticArrays
 
 include("slarray.jl")
 include("larray.jl")
+include("slsliced.jl")
+include("lsliced.jl")
 
 export SLArray, LArray, @SLVector, @LArray, @LVector, @SLArray
+
+export SLSlicedMatrix, LSlicedMatrix, @LSlicedMatrix, @SLSlicedMatrix
 
 end # module

--- a/src/lsliced.jl
+++ b/src/lsliced.jl
@@ -1,0 +1,128 @@
+struct LSlicedMatrix{T,N,Syms1,Syms2} <: DenseArray{T,N}
+  __x::Array{T,N}
+  LSlicedMatrix{Syms1,Syms2}(__x) where {Syms1,Syms2} = new{eltype(__x),ndims(__x),Syms1,Syms2}(__x)
+  LSlicedMatrix{T,N,Syms1,Syms2}(__x) where {T,N,Syms1,Syms2} = new{T,N,Syms1,Syms2}(__x)
+end
+
+# Allow chained getproperty with partial application of symbol lookup
+struct SlicePartial{Sym1,P}
+    __p::P
+end
+
+
+Base.size(x::LSlicedMatrix) = size(getfield(x,:__x))
+Base.propertynames(::LSlicedMatrix{T,A,Syms1,Syms2}) where {T,A,Syms1,Syms2} = Syms1, Syms2
+symnames(::Type{LSlicedMatrix{T,A,Syms1,Syms2}}) where {T,A,Syms1,Syms2} = Syms1, Syms2
+
+@inline function Base.getproperty(p::SlicePartial{Val{s1}},s2::Symbol) where s1
+  getfield(p, :__p)[Val(s1), Val(s2)]
+end
+
+@inline function Base.setproperty!(p::SlicePartial{Val{s1}},s2::Symbol,y) where s1
+  getfield(p, :__p)[Val(s1), Val(s2)] = y
+end
+
+
+@inline function Base.getproperty(x::Union{LSlicedMatrix,SLSlicedMatrix},s::Symbol)
+  if s == :__x
+    return getfield(x,:__x)
+  end
+  SlicePartial{Val{s},typeof(x)}(x)
+end
+
+@inline function Base.setproperty!(x::Union{LSlicedMatrix,SLSlicedMatrix},s::Symbol,y)
+  if s == :__x
+    return setfield!(x,:__x,y)
+  end
+  x[s] = y end
+
+@inline Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},i::Int...) = getfield(x,:__x)[i...]
+@inline Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))
+@inline Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},i1::Int,s2::Symbol) = getindex(x,i1::Int,Val(s2))
+@inline Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},s1::Symbol,i2) = getindex(x,Val(s1),i2)
+
+@inline @generated function Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},::Val{s1},::Val{s2}) where {s1, s2}
+  idx1 = findfirst(y->y==s1,symnames(x)[1])
+  idx2 = findfirst(y->y==s2,symnames(x)[2])
+  :(getfield(x,:__x)[$idx1, $idx2])
+end
+
+@inline @generated function Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},i1::Int,::Val{s2}) where s2
+  idx2 = findfirst(y->y==s2,symnames(x)[2])
+  :(getfield(x,:__x)[i1, $idx2])
+end
+
+@inline @generated function Base.getindex(x::Union{LSlicedMatrix,SLSlicedMatrix},::Val{s1},i2::Int) where s1
+  idx1 = findfirst(y->y==s1,symnames(x)[1])
+  :(getfield(x,:__x)[$idx1, i2])
+end
+
+
+@inline Base.setindex!(x::LSlicedMatrix,y,i...) = getfield(x,:__x)[i...] = y
+@inline Base.setindex!(x::LSlicedMatrix,y,s1::Symbol,s2::Symbol) = setindex!(x,y,Val(s1),Val(s2))
+@inline Base.setindex!(x::LSlicedMatrix,y,s1::Symbol,i2) = setindex!(x,y,Val(s1),i2)
+@inline Base.setindex!(x::LSlicedMatrix,y,i1,s2::Symbol) = setindex!(x,y,i1,Val(s2))
+@inline Base.setindex!(x::LSlicedMatrix,y,s1::Symbol,i2::Val) = setindex!(x,y,Val(s1),i2)
+@inline Base.setindex!(x::LSlicedMatrix,y,i1::Val,s2::Symbol) = setindex!(x,y,i1,Val(s2))
+
+@inline @generated function Base.setindex!(x::LSlicedMatrix,y,::Val{s1},::Val{s2}) where {s1, s2}
+    idx1 = findfirst(y->y==s1,symnames(x)[1])
+    idx2 = findfirst(y->y==s2,symnames(x)[2])
+    :(x.__x[$idx1, $idx2] = y)
+end
+@inline @generated function Base.setindex!(x::LSlicedMatrix,y,::Val{s1},i2::Number) where s1
+    idx1 = findfirst(y->y==s1,symnames(x)[1])
+    :(x.__x[$idx1, i2] = y)
+end
+@inline @generated function Base.setindex!(x::LSlicedMatrix,y,i1::Number,::Val{s2}) where s2
+    idx2 = findfirst(y->y==s2,symnames(x)[2])
+    :(x.__x[i1, $idx2] = y)
+end
+
+
+
+function Base.similar(x::LSlicedMatrix{T,K,Syms1,Syms2},::Type{S},dims::NTuple{N,Int}) where {T,Syms1,Syms2,S,N,K}
+  tmp = similar(x.__x,S,dims)
+  LSlicedMatrix{S,N,Syms1,Syms2}(tmp)
+end
+
+# enable the usage of LAPACK
+Base.unsafe_convert(::Type{Ptr{T}}, a::LSlicedMatrix{T,N,S}) where {T,N,S} = Base.unsafe_convert(Ptr{T}, getfield(a,:__x))
+
+#####################################
+# Broadcast
+#####################################
+struct LASlicedStyle{T,N,L1,L2} <: Broadcast.AbstractArrayStyle{N} end
+LASlicedStyle{T,N,L1,L2}(x::Val{2}) where {T,N,L1,L2} = LASlicedStyle{T,N,L1,L2}()
+Base.BroadcastStyle(::Type{LSlicedMatrix{T,N,L1,L2}}) where {T,N,L1,L2} = LASlicedStyle{T,N,L1,L2}()
+Base.BroadcastStyle(::LabelledArrays.LASlicedStyle{T,N,L1,L2}, ::LabelledArrays.LASlicedStyle{E,N,L1,L2}) where {T,E,N,L1,L2} = 
+  LASlicedStyle{promote_type(T,E),N,L1,L2}()
+
+function Base.similar(bc::Broadcast.Broadcasted{LASlicedStyle{T,N,L1,L2}}, ::Type{ElType}) where {T,N,L1,L2,ElType}
+  return LSlicedMatrix{ElType,N,L1,L2}(similar(Array{ElType,N},axes(bc)))
+end
+
+"""
+    @LSlicedMatrix Eltype Size Names
+    @LSlicedMatrix Values Names
+
+Creates an `LSlicedMatrix` with names determined from the `Names`
+vector and values determined from the `Values` array. Otherwise, and eltype
+and size are used to make an LSlicedMatrix with undefined values.
+
+For example:
+
+    a = @LSlicedMatrix Float64 (4,2) (:a,:b,:c,:d) (:x,:y,:z)
+    b = @LSlicedMatrix [1 2; 3 4; 5 6] (:a,:b,:c) (:x,:y)
+"""
+macro LSlicedMatrix(vals,syms1,syms2)
+  return quote
+    LSlicedMatrix{$syms1,$syms2}($vals)
+  end
+end
+
+macro LSlicedMatrix(type,size,syms1,syms2)
+  return quote
+    LSlicedMatrix{$syms1,$syms2}(Array{$type}(undef,$size...))
+  end
+end

--- a/src/slsliced.jl
+++ b/src/slsliced.jl
@@ -1,0 +1,53 @@
+struct SLSlicedMatrix{S,N,Syms1,Syms2,T} <: StaticArray{S,T,N}
+  __x::SArray{S,T,N}
+  #SLSlicedMatrix{Syms1,Syms2}(__x::StaticArray{S,T,N}) where {S,N,Syms1,Syms2,T} = new{S,N,Syms1,Syms2,T}(__x)
+  SLSlicedMatrix{S,N,Syms1,Syms2,T}(__x::SArray) where {S,N,Syms1,Syms2,T} = new{S,N,Syms1,Syms2,T}(T.(__x))
+  SLSlicedMatrix{S,N,Syms1,Syms2}(x::Tuple) where {S,N,Syms1,Syms2} = new{S,N,Syms1,Syms2,eltype(x)}(SArray{S,eltype(x),N}(x))
+  SLSlicedMatrix{S,N,Syms1,Syms2,T}(x::Tuple) where {S,N,Syms1,Syms2,T} = new{S,N,Syms1,Syms2,T}(SArray{S,T,N}(T.(x)))
+end
+
+# Implement the StaticVector interface
+@inline Base.getindex(x::SLSlicedMatrix, i::Int) = getfield(x,:__x)[i]
+@inline Base.Tuple(x::SLSlicedMatrix) = Tuple(x.__x)
+function StaticArrays.similar_type(::Type{SLSlicedMatrix{S,N,Syms1,Syms2,T}}, ::Type{NewElType},
+    ::Size{NewSize}) where {S,T,N,Syms1,Syms2,NewElType,NewSize}
+  @assert length(NewSize) == N
+  SLSlicedMatrix{S,N,Syms1,Syms2,NewElType}
+end
+
+Base.propertynames(::SLSlicedMatrix{S,N,Syms1,Syms2,T}) where {S,N,T,Syms1,Syms2} = Syms1,Syms2
+symnames(::Type{SLSlicedMatrix{S,N,Syms1,Syms2,T}}) where {S,N,T,Syms1,Syms2} = Syms1,Syms2
+
+"""
+    @SLSlicedMatrix Size Names1 Names2
+    @SLSlicedMatrix Eltype Size Names1 Names2
+
+Creates an anonymous function that builds a labelled static vector with eltype
+`ElType` with names determined from the `Names` with size `Size`. If no eltype
+is given, then the eltype is determined from the arguments in the constructor.
+
+For example:
+
+```julia
+ABC = @SLSlicedMatrix (4,2) (:a,:b,:c,:d) (:x,:y)
+x = ABC([1.0 2.5; 3.0 5.0; 9.0 11.4; 12.9 17.7])
+x.a.x == 1.0
+x.a.y == 2.5
+x.c.x == x[3,1]
+x.d.y == x[4,2]
+```
+
+"""
+macro SLSlicedMatrix(dims,syms1,syms2)
+  dims isa Expr && (dims = dims.args)
+  quote
+    SLSlicedMatrix{Tuple{$dims...,},$(length(dims)),$syms1,$syms2}
+  end
+end
+
+macro SLSlicedMatrix(T,dims,syms1,syms2)
+  dims isa Expr && (dims = dims.args)
+  quote
+    SLSlicedMatrix{Tuple{$dims...,},$(length(dims)),$syms1,$syms2,$T}
+  end
+end

--- a/test/lsliced.jl
+++ b/test/lsliced.jl
@@ -1,0 +1,42 @@
+using LabelledArrays, Test, InteractiveUtils
+
+x = @LSlicedMatrix [1.0 2.0; 3.0 4.0; 5.0 6.0] (:a,:b,:c) (:x, :y)
+
+syms1 = (:a,:b,:c)
+syms2 = (:x, :y)
+
+for (i,s1) in enumerate(syms1), (j,s2) in enumerate(syms2)
+    @show i,s2,j,s2
+    @test x[i,j] == x[s1,s2]
+end
+
+f(x) = x[1,1]
+g(x) = x.a.x
+@time f(x)
+@time f(x)
+@time g(x)
+@time g(x)
+
+#@code_warntype x.a
+#@inferred getindex(x,:a)
+@code_warntype g(x)
+@inferred g(x)
+
+x = @LSlicedMatrix [1 2; 3 4; 5 6] (:a,:b,:c) (:x, :y)
+@test x .* x isa LSlicedMatrix
+@test x .+ 1 isa LSlicedMatrix
+@test x .+ 1. isa LSlicedMatrix
+z = x .+ ones(Int, 3)
+@test z isa LSlicedMatrix && eltype(z) === Int
+z = x .+ ones(Float64, 3)
+@test z isa LSlicedMatrix && eltype(z) === Float64
+@test eltype(x .+ 1.) === Float64
+
+z = @LSlicedMatrix Float64 (2,2) (:a,:b) (:c,:d)
+w = rand(2,2)
+z .= w
+
+@test z[:a,:c] == w[1,1]
+@test z[:b,:c] == w[2,1]
+@test z[:a,:d] == w[1,2]
+@test z[:b,:d] == w[2,2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,7 @@ using StaticArrays
 @time begin
 @time @testset "SLArrays Macros" begin include("slarrays.jl") end
 @time @testset "LArrays" begin include("larrays.jl") end
+@time @testset "LSlicedMatrix" begin include("lsliced.jl") end
+@time @testset "SLSlicedMatrix" begin include("slsliced.jl") end
 @time @testset "DiffEq" begin include("diffeq.jl") end
 end

--- a/test/slsliced.jl
+++ b/test/slsliced.jl
@@ -1,0 +1,25 @@
+using LabelledArrays, Test, StaticArrays
+
+ABC = @SLSlicedMatrix (3, 2) (:a,:b,:c) (:x, :y) 
+b = ABC(1,2,3,4,5,6)
+
+@test b.a.x == 1
+@test b.b.x == 2
+@test b.c.y == 6
+@test b[1,1] == b.a.x
+@test b[2,2] == b.b.y
+@test b[3,1] == b.c.x
+
+@test_throws UndefVarError fill!(a,1)
+@test typeof(b.__x) == SArray{Tuple{3,2},Int,2,6}
+
+# Type stability tests
+ABC_fl = @SLSlicedMatrix Float64 (3,2) (:a, :b, :c) (:x, :y)
+ABC_int = @SLSlicedMatrix Int (3,2) (:a, :b, :c) (:x, :y)
+@test similar_type(b, Float64) == ABC_fl
+@test typeof(copy(b)) == ABC_int
+@test typeof(Float64.(b)) == ABC_fl
+@test typeof(b .+ b) == ABC_int
+@test typeof(b .+ 1.0) == ABC_fl
+@test typeof(zero(b)) == ABC_int
+@test similar(b) isa MArray # similar should return a mutable copy


### PR DESCRIPTION
I decided not to touch larray.jl or slarray.jl at all, there may be some consolidation possible but it also may not be worth the effort. Its similar except the added dimension everywhere, and the SlicePartial type for partial application of getproperty, so we can use x.a.b instead of x[:a, :b]

It seems to work very well. The performance is comparable to standard labelled arrays, even the partial application of getproperty for the first dimension seems to be compiled away at no cost.

I'm not exited about the name LSlicedMatrix so consider it a placeholder for something better. Ideas appreciated!