### PR TITLE
add slice labelled versions of LArray and SLArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ julia> SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
  2  4
 ```
 
+
+
 ## LArrays
 
 The `LArrayz`s are fully mutable arrays with labels. There is no performance
@@ -96,6 +98,29 @@ julia> LArray((2,2); a=1, b=2, c=3, d=4) # need to specify size as first argumen
 2×2 LArray{Int64,2,(:a, :b, :c, :d)}:
  1  3
  2  4
+```
+
+## Labelled slices
+
+For a labelled array where the row and column slices are labeled, use `@SLSlice`
+and `@LSlice`, similar to `@SLArray` and `@LArray` but passing a _tuple_ of label
+tuples.
+
+For static arrays with labeled rows and columns:
+
+```
+ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y)
+A = ABC([1 2; 3 4; 5 6])
+A.a.x == 1
+A[:c, :y] == 6
+```
+
+For regular arrays with labeled rows and columns:
+
+```
+A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+A.a.x == 1
+A[:c, :y] == 6
 ```
 
 ## Example: Nice DiffEq Syntax Without A DSL

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -4,8 +4,12 @@ using LinearAlgebra, StaticArrays
 
 include("slarray.jl")
 include("larray.jl")
+include("slsliced.jl")
+include("lsliced.jl")
 include("display.jl")
 
 export SLArray, LArray, SLVector, LVector, @SLVector, @LArray, @LVector, @SLArray
+
+export @SLSliced, @LSliced
 
 end # module

--- a/src/lsliced.jl
+++ b/src/lsliced.jl
@@ -1,0 +1,109 @@
+
+const LSliced = LArray{T,N,Syms} where {T,N,Syms<:Tuple}
+const SLSliced = SLArray{S,T,N,L,Syms} where {S,T,N,L,Syms<:Tuple}
+const Sliced = Union{SLSliced,LSliced}
+
+# Allow chained getproperty with partial application of the symbol lookup
+struct SlicePartial{Syms1,P}
+    __p::P
+end
+
+@inline function Base.getproperty(p::SlicePartial{Val{s1}},s2::Symbol) where s1
+  getfield(p, :__p)[Val(s1), Val(s2)]
+end
+
+@inline function Base.setproperty!(p::SlicePartial{Val{s1}},s2::Symbol,y) where s1
+  getfield(p, :__p)[Val(s1), Val(s2)] = y
+end
+
+@inline function Base.getproperty(x::Sliced,s::Symbol)
+  if s == :__x
+    return getfield(x,:__x)
+  end
+  SlicePartial{Val{s},typeof(x)}(x)
+end
+
+
+#####################################
+# Array Interface 
+# (getindex/getproperty methods are shared with SLArray
+#####################################
+Base.propertynames(::LArray{T,N,S}) where {T,N,S<:Tuple{Syms1,Syms2}} where {Syms1,Syms2} = Syms1, Syms2
+symnames(::Type{LArray{T,N,S}}) where {T,N,S<:Tuple{Syms1,Syms2}} where {Syms1,Syms2} = Syms1, Syms2
+
+@inline Base.getindex(x::Sliced,i::Int...) = getfield(x,:__x)[i...]
+@inline Base.getindex(x::Sliced,s1::Symbol,s2::Symbol) = getindex(x,Val(s1),Val(s2))
+@inline Base.getindex(x::Sliced,i1::Int,s2::Symbol) = getindex(x,i1::Int,Val(s2))
+@inline Base.getindex(x::Sliced,s1::Symbol,i2)   = getindex(x,Val(s1),i2)
+
+@inline @generated function Base.getindex(x::Sliced,::Val{s1},::Val{s2}) where {s1,s2}
+  idx1 = findfirst(y->y==s1,symnames(x)[1])
+  idx2 = findfirst(y->y==s2,symnames(x)[2])
+  :(getfield(x,:__x)[$idx1, $idx2])
+end
+
+@inline @generated function Base.getindex(x::Sliced,i1::Int,::Val{s2}) where s2
+  idx2 = findfirst(y->y==s2,symnames(x)[2])
+  :(getfield(x,:__x)[i1, $idx2])
+end
+
+@inline @generated function Base.getindex(x::Sliced,::Val{s1},i2::Int) where s1
+  idx1 = findfirst(y->y==s1,symnames(x)[1])
+  :(getfield(x,:__x)[$idx1, i2])
+end
+
+
+
+@inline Base.setindex!(x::LSliced,y,i...) = getfield(x,:__x)[i...] = y
+@inline Base.setindex!(x::LSliced,y,s1::Symbol,s2::Symbol) = setindex!(x,y,Val(s1),Val(s2))
+@inline Base.setindex!(x::LSliced,y,s1::Symbol,i2) = setindex!(x,y,Val(s1),i2)
+@inline Base.setindex!(x::LSliced,y,i1,s2::Symbol) = setindex!(x,y,i1,Val(s2))
+@inline Base.setindex!(x::LSliced,y,s1::Symbol,i2::Val) = setindex!(x,y,Val(s1),i2)
+@inline Base.setindex!(x::LSliced,y,i1::Val,s2::Symbol) = setindex!(x,y,i1,Val(s2))
+
+@inline @generated function Base.setindex!(x::LSliced,y,::Val{s1},::Val{s2}) where {s1, s2}
+    idx1 = findfirst(y->y==s1,symnames(x)[1])
+    idx2 = findfirst(y->y==s2,symnames(x)[2])
+    :(x.__x[$idx1, $idx2] = y)
+end
+
+@inline @generated function Base.setindex!(x::LSliced,y,::Val{s1},i2::Number) where s1
+    idx1 = findfirst(y->y==s1,symnames(x)[1])
+    :(x.__x[$idx1, i2] = y)
+end
+
+@inline @generated function Base.setindex!(x::LSliced,y,i1::Number,::Val{s2}) where s2
+    idx2 = findfirst(y->y==s2,symnames(x)[2])
+    :(x.__x[i1, $idx2] = y)
+end
+
+
+#####################################
+# Broadcast
+#####################################
+LAStyle{T,N,Syms}(x::Val{2}) where {T,N,Syms<:Tuple} = LAStyle{T,N,Syms}()
+
+"""
+    @LSliced Eltype Size Names
+    @LSliced Values Names
+
+Creates a `LArray` where the rows and columns are labelled instead of individual cells.
+Names are determined from the `Names` tuples and values determined from the `Values` array.
+Otherwise, and eltype and size are used to make an LArray with undefined values.
+
+For example:
+
+    a = @LSliced Float64 (4,2) (:a,:b,:c,:d), (:x,:y,:z)
+    b = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x,:y)
+"""
+macro LSliced(vals,syms)
+  return quote
+    LArray{Tuple{$syms...,}}($vals)
+  end
+end
+
+macro LSliced(type,size,syms)
+  return quote
+    LArray{Tuple{$syms...,}}(Array{$type}(undef,$size...))
+  end
+end

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -54,8 +54,12 @@ Base.pairs(x::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} =
 @inline Base.Tuple(x::SLArray) = Tuple(x.__x)
 function StaticArrays.similar_type(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElType},
     ::Size{NewSize}) where {S,T,N,L,Syms,NewElType,NewSize}
-  @assert length(NewSize) == N
-  SLArray{S,NewElType,Syms}
+  n = prod(NewSize)
+  if n == L
+    SLArray{Tuple{NewSize...},NewElType,length(NewSize),L,Syms}
+  else
+    SArray{Tuple{NewSize...},NewElType,length(NewSize),n}
+  end
 end
 
 Base.propertynames(::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} = Syms
@@ -94,14 +98,14 @@ x.d == x[2,2]
 macro SLArray(dims,syms)
   dims isa Expr && (dims = dims.args)
   quote
-    SLArray{Tuple{$dims...,},$syms}
+    SLArray{Tuple{$dims...},$syms}
   end
 end
 
 macro SLArray(T,dims,syms)
   dims isa Expr && (dims = dims.args)
   quote
-    SLArray{Tuple{$dims...,},$T,$syms}
+    SLArray{Tuple{$dims...},$T,$(length(dims)),$(prod(dims)),$syms}
   end
 end
 
@@ -134,6 +138,6 @@ end
 macro SLVector(T,syms)
   n = syms isa Expr ? length(syms.args) : length(syms)
   quote
-    SLArray{Tuple{$n},$T,$syms}
+    SLArray{Tuple{$n},$T,1,$n,$syms}
   end
 end

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -52,6 +52,7 @@ Base.pairs(x::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} =
 #####################################
 @inline Base.getindex(x::SLArray, i::Int) = getfield(x,:__x)[i]
 @inline Base.Tuple(x::SLArray) = Tuple(x.__x)
+
 function StaticArrays.similar_type(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElType},
     ::Size{NewSize}) where {S,T,N,L,Syms,NewElType,NewSize}
   n = prod(NewSize)
@@ -59,6 +60,15 @@ function StaticArrays.similar_type(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElTy
     SLArray{Tuple{NewSize...},NewElType,length(NewSize),L,Syms}
   else
     SArray{Tuple{NewSize...},NewElType,length(NewSize),n}
+  end
+end
+
+function Base.similar(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElType}, ::Size{NewSize}) where {S,T,N,L,Syms,NewElType,NewSize}
+  n = prod(NewSize)
+  if n == L
+    LArray{NewElType,length(NewSize),Syms}(Array{NewElType}(undef, NewSize))
+  else
+    MArray{Tuple{NewSize...},NewElType,length(NewSize),n}(undef)
   end
 end
 

--- a/src/slsliced.jl
+++ b/src/slsliced.jl
@@ -35,6 +35,6 @@ end
 macro SLSliced(T,dims,syms)
   dims isa Expr && (dims = dims.args)
   quote
-      SLArray{Tuple{$dims...,},$T,Tuple{$syms...,}}
+      SLArray{Tuple{$dims...},$T,$(length(dims)),$(prod(dims)),Tuple{$syms...}}
   end
 end

--- a/src/slsliced.jl
+++ b/src/slsliced.jl
@@ -1,0 +1,40 @@
+
+#####################################
+# StaticArray Interface
+#####################################
+Base.propertynames(::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms<:Tuple{Syms1,Syms2}} where {Syms1,Syms2} = Syms1,Syms2
+symnames(::Type{SLArray{S,T,N,L,Syms}}) where {S,T,N,L,Syms<:Tuple{Syms1,Syms2}} where {Syms1,Syms2} = Syms1,Syms2
+
+"""
+    @SLSliced Size Names1, Names2
+    @SLSlice Eltype Size Names1, Names2
+
+Creates an anonymous function that builds a labelled static vector with eltype
+`ElType` with names determined from the `Names` tuple with size `Size`. If no eltype
+is given, then the eltype is determined from the arguments in the constructor.
+
+For example:
+
+```julia
+ABC = @SLSliced (4,2) (:a,:b,:c,:d), (:x,:y)
+x = ABC([1.0 2.5; 3.0 5.0; 9.0 11.4; 12.9 17.7])
+x.a.x == 1.0
+x.a.y == 2.5
+x.c.x == x[3,1]
+x.d.y == x[4,2]
+```
+
+"""
+macro SLSliced(dims,syms)
+  dims isa Expr && (dims = dims.args)
+  quote
+    SLArray{Tuple{$dims...,},Tuple{$syms...,}}
+  end
+end
+
+macro SLSliced(T,dims,syms)
+  dims isa Expr && (dims = dims.args)
+  quote
+      SLArray{Tuple{$dims...,},$T,Tuple{$syms...,}}
+  end
+end

--- a/test/lsliced.jl
+++ b/test/lsliced.jl
@@ -1,0 +1,63 @@
+using LabelledArrays, Test, InteractiveUtils
+
+@testset "Basic interface" begin
+    x = @LSliced [1.0 2.0; 3.0 4.0; 5.0 6.0] (:a,:b,:c), (:x, :y)
+
+    syms1 = (:a,:b,:c)
+    syms2 = (:x, :y)
+
+    for (i,s1) in enumerate(syms1), (j,s2) in enumerate(syms2)
+        @show i,s2,j,s2
+        @test x[i,j] == x[s1,s2]
+    end
+
+    f(x) = x[1,1]
+    g(x) = x.a.x
+    @time f(x)
+    @time f(x)
+    @time g(x)
+    @time g(x)
+
+    #@code_warntype x.a
+    #@inferred getindex(x,:a)
+    @code_warntype g(x)
+    @inferred g(x)
+
+    x = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    @test x .* x isa LArray
+    @test x .+ 1 isa LArray
+    @test x .+ 1. isa LArray
+    z = x .+ ones(Int, 3)
+    @test z isa LArray && eltype(z) === Int
+    z = x .+ ones(Float64, 3)
+    @test z isa LArray && eltype(z) === Float64
+    @test eltype(x .+ 1.) === Float64
+
+    z = @LSliced Float64 (2,2) (:a,:b), (:c,:d)
+    w = rand(2,2)
+    z .= w
+
+    @test z[:a,:c] == w[1,1]
+    @test z[:b,:c] == w[2,1]
+    @test z[:a,:d] == w[1,2]
+    @test z[:b,:d] == w[2,2]
+
+    x = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    x.a.x = 33
+    x.b.y = 99
+    x[:a,:y] = 44
+    x[:b,:x] = 77
+    @test x[1,1] == 33
+    @test x[2,2] == 99
+    @test x[1,2] == 44
+    @test x[2,1] == 77
+end
+
+
+@testset "undef copy" begin
+    z = @LSliced Float64 (4,2) (:a,:b,:c,:d), (:x, :y)
+    t = similar(z, String) # t's elements are uninitialized
+    @test_throws UndefRefError t[1]
+    copy(t) # should be ok
+    deepcopy(t) # should also be ok
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using StaticArrays
 @time begin
 @time @testset "SLArrays" begin include("slarrays.jl") end
 @time @testset "LArrays" begin include("larrays.jl") end
+@time @testset "LSliced" begin include("lsliced.jl") end
+@time @testset "SLSliced" begin include("slsliced.jl") end
 @time @testset "DiffEq" begin include("diffeq.jl") end
 @time @testset "Display" begin include("display.jl") end
 end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -18,13 +18,15 @@ using Test, InteractiveUtils
     # Type stability tests
     ABC_fl = @SLVector Float64 (:a, :b, :c)
     ABC_int = @SLVector Int (:a, :b, :c)
-    @test similar_type(b, Float64) === ABC_fl
-    @test copy(b) === ABC_int(Tuple(b))
-    @test Float64.(b) === ABC_fl(Tuple(b))
-    @test b .+ b === ABC_int(Tuple(b.__x .+ b.__x))
-    @test b .+ 1.0 === ABC_fl(Tuple(b.__x .+ 1.0))
-    @test zero(b) === ABC_int(zero(b))
-    @test typeof(similar(b)) === MArray{Tuple{3}, Int, 1, 3} # similar should return a mutable copy
+    @test @inferred(similar_type(b, Float64)) === ABC_fl
+    @test @inferred(similar_type(b, Float64, Size(1,3))) === @SLArray Float64 (1,3) (:a, :b, :c)
+    @test @inferred(similar_type(b, Float64, Size(3,3))) === SArray{Tuple{3,3},Float64,2,9}
+    @test @inferred(copy(b)) === ABC_int(Tuple(b))
+    @test @inferred(broadcast(Float64, b)) === ABC_fl(Tuple(b))
+    @test @inferred(broadcast(+, b, b)) === ABC_int(Tuple(b.__x .+ b.__x))
+    @test @inferred(broadcast(+, b, 1.0)) === ABC_fl(Tuple(b.__x .+ 1.0))
+    @test @inferred(zero(b)) === ABC_int(zero(b))
+    @test typeof(@inferred(similar(b))) === MArray{Tuple{3}, Int, 1, 3} # similar should return a mutable copy
 end
 
 @testset "NamedTuple conversion" begin
@@ -32,12 +34,12 @@ end
     y_tup = (a=1, b=2, c=3, d=4)
     x = SLVector(a=1, b=2)
     y = SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
-    @test convert(NamedTuple, x) == x_tup
-    @test convert(NamedTuple, y) == y_tup
-    @test collect(pairs(x)) == collect(pairs(x_tup))
-    @test collect(pairs(y)) == collect(pairs(y_tup))
+    @test @inferred(convert(NamedTuple, x)) == x_tup
+    @test @inferred(convert(NamedTuple, y)) == y_tup
+    @test @inferred(collect(pairs(x))) == collect(pairs(x_tup))
+    @test @inferred(collect(pairs(y))) == collect(pairs(y_tup))
 
-    @code_warntype SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4)
-    @code_warntype convert(NamedTuple, y)
-    @code_warntype collect(pairs(y))
+    @inferred(SLArray{Tuple{2,2}}(a=1, b=2, c=3, d=4))
+    @inferred(convert(NamedTuple, y))
+    @inferred(collect(pairs(y)))
 end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -18,15 +18,23 @@ using Test, InteractiveUtils
     # Type stability tests
     ABC_fl = @SLVector Float64 (:a, :b, :c)
     ABC_int = @SLVector Int (:a, :b, :c)
+
     @test @inferred(similar_type(b, Float64)) === ABC_fl
     @test @inferred(similar_type(b, Float64, Size(1,3))) === @SLArray Float64 (1,3) (:a, :b, :c)
     @test @inferred(similar_type(b, Float64, Size(3,3))) === SArray{Tuple{3,3},Float64,2,9}
+
+    @test typeof(@inferred(similar(b))) === LArray{Int,1,(:a,:b,:c)}
+    @test typeof(@inferred(similar(b, Float64))) === LArray{Float64,1,(:a,:b,:c)}
+    @test typeof(@inferred(similar(b, Size(1,3)))) === LArray{Int,2,(:a, :b, :c)}
+    @test typeof(@inferred(similar(b, Size(3,3)))) === MArray{Tuple{3,3},Int,2,9}
+
     @test @inferred(copy(b)) === ABC_int(Tuple(b))
+
     @test @inferred(broadcast(Float64, b)) === ABC_fl(Tuple(b))
     @test @inferred(broadcast(+, b, b)) === ABC_int(Tuple(b.__x .+ b.__x))
     @test @inferred(broadcast(+, b, 1.0)) === ABC_fl(Tuple(b.__x .+ 1.0))
+
     @test @inferred(zero(b)) === ABC_int(zero(b))
-    @test typeof(@inferred(similar(b))) === MArray{Tuple{3}, Int, 1, 3} # similar should return a mutable copy
 end
 
 @testset "NamedTuple conversion" begin

--- a/test/slsliced.jl
+++ b/test/slsliced.jl
@@ -1,0 +1,25 @@
+using LabelledArrays, Test, StaticArrays
+
+ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y) 
+b = ABC(1,2,3,4,5,6)
+
+@test b.a.x == 1
+@test b.b.x == 2
+@test b.c.y == 6
+@test b[1,1] == b.a.x
+@test b[2,2] == b.b.y
+@test b[3,1] == b.c.x
+
+@test_throws UndefVarError fill!(a,1)
+@test typeof(b.__x) == SArray{Tuple{3,2},Int,2,6}
+
+# Type stability tests
+ABC_fl = @SLSliced Float64 (3,2) (:a, :b, :c), (:x, :y)
+ABC_int = @SLSliced Int (3,2) (:a, :b, :c), (:x, :y)
+@test similar_type(b, Float64) === ABC_fl
+@test copy(b) === ABC_int(Tuple(b))
+@test Float64.(b) === ABC_fl(Tuple(b))
+@test b .+ b === ABC_int(Tuple(b.__x .+ b.__x))
+@test b .+ 1.0 === ABC_fl(Tuple(b.__x .+ 1.0))
+@test zero(b) === ABC_int(zero(b))
+@test typeof(similar(b)) === MArray{Tuple{3,2}, Int, 2, 6} # similar should return a mutable copy

--- a/test/slsliced.jl
+++ b/test/slsliced.jl
@@ -1,25 +1,36 @@
 using LabelledArrays, Test, StaticArrays
 
-ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y) 
-b = ABC(1,2,3,4,5,6)
+@testset "Basic interface" begin
+    ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y) 
+    b = ABC(1,2,3,4,5,6)
 
-@test b.a.x == 1
-@test b.b.x == 2
-@test b.c.y == 6
-@test b[1,1] == b.a.x
-@test b[2,2] == b.b.y
-@test b[3,1] == b.c.x
+    @test b.a.x == 1
+    @test b.b.x == 2
+    @test b.c.y == 6
+    @test b[1,1] == b.a.x
+    @test b[2,2] == b.b.y
+    @test b[3,1] == b.c.x
+    @test_throws UndefVarError fill!(a,1)
+    @test typeof(b.__x) == SArray{Tuple{3,2},Int,2,6}
 
-@test_throws UndefVarError fill!(a,1)
-@test typeof(b.__x) == SArray{Tuple{3,2},Int,2,6}
+    # Type stability tests
+    ABC_fl = @SLSliced Float64 (3,2) (:a, :b, :c), (:x, :y)
+    ABC_int = @SLSliced Int (3,2) (:a, :b, :c), (:x, :y)
 
-# Type stability tests
-ABC_fl = @SLSliced Float64 (3,2) (:a, :b, :c), (:x, :y)
-ABC_int = @SLSliced Int (3,2) (:a, :b, :c), (:x, :y)
-@test similar_type(b, Float64) === ABC_fl
-@test copy(b) === ABC_int(Tuple(b))
-@test Float64.(b) === ABC_fl(Tuple(b))
-@test b .+ b === ABC_int(Tuple(b.__x .+ b.__x))
-@test b .+ 1.0 === ABC_fl(Tuple(b.__x .+ 1.0))
-@test zero(b) === ABC_int(zero(b))
-@test typeof(similar(b)) === MArray{Tuple{3,2}, Int, 2, 6} # similar should return a mutable copy
+    @test @inferred(similar_type(b, Float64)) === ABC_fl
+    @test @inferred(similar_type(b, Float64, Size(3,2))) === @SLSliced Float64 (3,2) (:a, :b, :c), (:x, :y)
+    @test @inferred(similar_type(b, Float64, Size(3,3))) === SArray{Tuple{3,3},Float64,2,9}
+
+    @test typeof(@inferred(similar(b))) === LArray{Int,2,Tuple{(:a,:b,:c),(:x,:y)}}
+    @test typeof(@inferred(similar(b, Float64))) === LArray{Float64,2,Tuple{(:a,:b,:c),(:x,:y)}}
+    @test typeof(@inferred(similar(b, Size(3,2)))) === LArray{Int,2,Tuple{(:a, :b, :c),(:x,:y)}}
+    @test typeof(@inferred(similar(b, Size(3,3)))) === MArray{Tuple{3,3},Int,2,9}
+
+    @test @inferred(copy(b)) === ABC_int(Tuple(b))
+
+    @test @inferred(broadcast(Float64, b)) === ABC_fl(Tuple(b))
+    @test @inferred(broadcast(+, b, b)) === ABC_int(Tuple(b.__x .+ b.__x))
+    @test @inferred(broadcast(+, b, 1.0)) === ABC_fl(Tuple(b.__x .+ 1.0))
+
+    @test @inferred(zero(b)) === ABC_int(zero(b))
+end


### PR DESCRIPTION
Attempt 2. This version just uses LArray and SLArtray with the sym tuples wrapped in a Tuple type.

SlicePartial allows partial getproperty. get/set methods dispatch on `Syms` being `<:Tuple{Syms1,Syms2}`
