### PR TITLE
Implement similar for SLArray

### DIFF
--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -52,6 +52,7 @@ Base.pairs(x::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} =
 #####################################
 @inline Base.getindex(x::SLArray, i::Int) = getfield(x,:__x)[i]
 @inline Base.Tuple(x::SLArray) = Tuple(x.__x)
+
 function StaticArrays.similar_type(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElType},
     ::Size{NewSize}) where {S,T,N,L,Syms,NewElType,NewSize}
   n = prod(NewSize)
@@ -59,6 +60,15 @@ function StaticArrays.similar_type(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElTy
     SLArray{Tuple{NewSize...},NewElType,length(NewSize),L,Syms}
   else
     SArray{Tuple{NewSize...},NewElType,length(NewSize),n}
+  end
+end
+
+function Base.similar(::Type{SLArray{S,T,N,L,Syms}}, ::Type{NewElType}, ::Size{NewSize}) where {S,T,N,L,Syms,NewElType,NewSize}
+  n = prod(NewSize)
+  if n == L
+    LArray{NewElType,length(NewSize),Syms}(Array{NewElType}(undef, NewSize))
+  else
+    MArray{Tuple{NewSize...},NewElType,length(NewSize),n}(undef)
   end
 end
 

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -18,15 +18,23 @@ using Test, InteractiveUtils
     # Type stability tests
     ABC_fl = @SLVector Float64 (:a, :b, :c)
     ABC_int = @SLVector Int (:a, :b, :c)
+
     @test @inferred(similar_type(b, Float64)) === ABC_fl
     @test @inferred(similar_type(b, Float64, Size(1,3))) === @SLArray Float64 (1,3) (:a, :b, :c)
     @test @inferred(similar_type(b, Float64, Size(3,3))) === SArray{Tuple{3,3},Float64,2,9}
+
+    @test typeof(@inferred(similar(b))) === LArray{Int,1,(:a,:b,:c)}
+    @test typeof(@inferred(similar(b, Float64))) === LArray{Float64,1,(:a,:b,:c)}
+    @test typeof(@inferred(similar(b, Size(1,3)))) === LArray{Int,2,(:a, :b, :c)}
+    @test typeof(@inferred(similar(b, Size(3,3)))) === MArray{Tuple{3,3},Int,2,9}
+
     @test @inferred(copy(b)) === ABC_int(Tuple(b))
+
     @test @inferred(broadcast(Float64, b)) === ABC_fl(Tuple(b))
     @test @inferred(broadcast(+, b, b)) === ABC_int(Tuple(b.__x .+ b.__x))
     @test @inferred(broadcast(+, b, 1.0)) === ABC_fl(Tuple(b.__x .+ 1.0))
+
     @test @inferred(zero(b)) === ABC_int(zero(b))
-    @test typeof(@inferred(similar(b))) === MArray{Tuple{3}, Int, 1, 3} # similar should return a mutable copy
 end
 
 @testset "NamedTuple conversion" begin


### PR DESCRIPTION
This PR implements `similar` for `SLArray`, which depending on the desired length creates a `LArray` or a `MArray`. It feels slightly inconsistent since one case creates an `Array` whereas the other one creates a `StaticArray`. Maybe a `MLArray` would be more appropriate.