### PR TITLE
access labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+test/tmp.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
-test/tmp.jl

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ julia> LArray((2,2); a=1, b=2, c=3, d=4) # need to specify size as first argumen
  2  4
 ```
 
+The labels of LArray and SLArray can be accessed 
+by function `symbols`, which returns a tuple of symbols.
+
+
 ## Labelled slices
 
 For a labelled array where the row and column slices are labeled, use `@SLSlice`
@@ -122,6 +126,13 @@ A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
 A.a.x == 1
 A[:c, :y] == 6
 ```
+
+The labels of LSliced and SLScliced can be accessed 
+by function `symbols`, which returns a `Tuple{(rowSymbols),(colSymobls),...}`
+Convenience functions `dimSymobls`, `rowSymbols`, and `colSymbols` 
+return a tuple of symbols of the
+labels associated to the respective dimension.
+
 
 ## Example: Nice DiffEq Syntax Without A DSL
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ A[:c, :y] == 6
 ```
 
 The labels of LSliced and SLScliced can be accessed 
-by function `symbols`, which returns a `Tuple{(rowSymbols),(colSymobls),...}`
-Convenience functions `dimSymobls`, `rowSymbols`, and `colSymbols` 
+by function `symbols`, which returns a `Tuple{(rowSymbols),(colSymbols),...}`
+Convenience functions `dimSymbols`, `rowSymbols`, and `colSymbols` 
 return a tuple of symbols of the
 labels associated to the respective dimension.
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,16 @@ A[:c, :y] == 6
 ```
 
 The labels of LSliced and SLScliced can be accessed 
-by function `symbols`, which returns a `Tuple{(rowSymbols),(colSymbols),...}`
-Convenience functions `dimSymbols`, `rowSymbols`, and `colSymbols` 
-return a tuple of symbols of the
-labels associated to the respective dimension.
+by function `symbols`.
+For a two-dimensional LSliced or SLSliced, it returns a tuple
+with first entry a tuple of row symbols and second entry a tuple of column symbols.
+For higher-dimensional slices, it returns a Tuple-Type object with
+parameters referring to the names of the dimensions.
 
+```
+A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+symbols(A)[1] == (:a, :b, :c)
+```
 
 ## Example: Nice DiffEq Syntax Without A DSL
 

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -12,4 +12,6 @@ export SLArray, LArray, SLVector, LVector, @SLVector, @LArray, @LVector, @SLArra
 
 export @SLSliced, @LSliced
 
+export symbols, dimSymbols, rowSymbols, colSymbols
+
 end # module

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -148,3 +148,19 @@ macro LVector(type,syms)
       LArray{$syms}(Vector{$type}(undef,length($syms)))
   end
 end
+
+#the following gives errror: TypeError: in <:, expected Type, got TypeVar
+#symbols(::LArray{T,N,D<:AbstractArray{T,N},Syms}) where {T,N,D,Syms} = Syms
+
+"""
+    symbols(::LArray{T,N,D,Syms})
+
+Returns the labels of the `LArray` .
+
+For example:
+
+    z = @LVector Float64 (:a,:b,:c,:d)
+    symbols(z)  # NTuple{4,Symbol} == (:a, :b, :c, :d)
+"""
+symbols(::LArray{T,N,D,Syms}) where {T,N,D,Syms} = Syms
+

--- a/src/lsliced.jl
+++ b/src/lsliced.jl
@@ -110,3 +110,46 @@ macro LSliced(type,size,syms)
       LArray{Tuple{$syms...,}}(Array{$type}(undef,$size...))
   end
 end
+
+
+"""
+dimSymbols(dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where {Syms<:Tuple}
+
+Returns the labels of the `LArray` associated with dimension `dim`.
+
+For example:
+
+    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    dimSymbols(A,1)  # (:a, :b, :c)
+"""
+dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where 
+{T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[dim]
+
+"""
+    dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where {Syms<:Tuple}
+
+Returns the labels of the `SLArray` associated with dimension `dim`.
+
+For example:
+
+    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    dimSymbols(A,2)  # (:x, :y)
+"""
+dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where 
+{S,T,N,L,Syms<:Tuple} = Syms.parameters[dim]
+
+"returns dimSymbols(,1)"
+rowSymbols(::LArray{T,N,D,Syms}) where 
+{T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[1]
+
+"returns dimSymbols(,1)"
+rowSymbols(::SLArray{S,T,N,L,Syms}) where 
+{S,T,N,L,Syms<:Tuple} = Syms.parameters[1]
+
+"returns dimSymbols(,2)"
+colSymbols(::LArray{T,N,D,Syms}) where 
+{T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[2]
+
+"returns dimSymbols(,2)"
+colSymbols(::SLArray{S,T,N,L,Syms}) where 
+{S,T,N,L,Syms<:Tuple} = Syms.parameters[2]

--- a/src/lsliced.jl
+++ b/src/lsliced.jl
@@ -125,31 +125,11 @@ For example:
 dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where 
 {T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[dim]
 
-"""
-    dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where {Syms<:Tuple}
-
-Returns the labels of the `SLArray` associated with dimension `dim`.
-
-For example:
-
-    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
-    dimSymbols(A,2)  # (:x, :y)
-"""
-dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where 
-{S,T,N,L,Syms<:Tuple} = Syms.parameters[dim]
-
 "returns dimSymbols(,1)"
 rowSymbols(::LArray{T,N,D,Syms}) where 
 {T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[1]
-
-"returns dimSymbols(,1)"
-rowSymbols(::SLArray{S,T,N,L,Syms}) where 
-{S,T,N,L,Syms<:Tuple} = Syms.parameters[1]
 
 "returns dimSymbols(,2)"
 colSymbols(::LArray{T,N,D,Syms}) where 
 {T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[2]
 
-"returns dimSymbols(,2)"
-colSymbols(::SLArray{S,T,N,L,Syms}) where 
-{S,T,N,L,Syms<:Tuple} = Syms.parameters[2]

--- a/src/lsliced.jl
+++ b/src/lsliced.jl
@@ -112,24 +112,26 @@ macro LSliced(type,size,syms)
 end
 
 
-"""
-dimSymbols(dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where {Syms<:Tuple}
+# """
+# dimSymbols(dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where {Syms<:Tuple}
 
-Returns the labels of the `LArray` associated with dimension `dim`.
+# Returns the labels of the `LArray` associated with dimension `dim`.
 
-For example:
+# For example:
 
-    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
-    dimSymbols(A,1)  # (:a, :b, :c)
-"""
-dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where 
-{T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[dim]
+#     A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+#     dimSymbols(A,1)  # (:a, :b, :c)
+# """
+# dimSymbols(::LArray{T,N,D,Syms}, dim::Int) where 
+# {T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[dim]
 
-"returns dimSymbols(,1)"
-rowSymbols(::LArray{T,N,D,Syms}) where 
-{T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[1]
+# "returns dimSymbols(,1)"
+# rowSymbols(::LArray{T,N,D,Syms}) where 
+# {T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[1]
 
-"returns dimSymbols(,2)"
-colSymbols(::LArray{T,N,D,Syms}) where 
-{T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[2]
+# "returns dimSymbols(,2)"
+# colSymbols(::LArray{T,N,D,Syms}) where 
+# {T,N,D<:AbstractArray{T,N},Syms<:Tuple} = Syms.parameters[2]
 
+symbols(::LArray{T,N,D,Syms}) where 
+{rows,cols,T,N,D,Syms<:Tuple{rows,cols}} = rows,cols

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -155,3 +155,17 @@ macro SLVector(T,syms)
     SLArray{Tuple{n},$T,1,n,$syms}
   end
 end
+
+"""
+    symbols(::SLArray{T,N,D,Syms})
+
+Returns the labels of the `SLArray` .
+
+For example:
+
+    z = SLVector(a=1, b=2, c=3)
+    symbols(z)  # Tuple{Symbol,Symbol,Symbol} == (:a, :b, :c)
+"""
+symbols(::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} = Syms
+
+

--- a/src/slsliced.jl
+++ b/src/slsliced.jl
@@ -43,23 +43,27 @@ macro SLSliced(T,dims,syms)
 end
 
 
-"""
-    dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where {Syms<:Tuple}
+# """
+#     dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where {Syms<:Tuple}
 
-Returns the labels of the `SLArray` associated with dimension `dim`.
+# Returns the labels of the `SLArray` associated with dimension `dim`.
 
-For example:
+# For example:
 
-    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
-    dimSymbols(A,2)  # (:x, :y)
-"""
-dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where 
-{S,T,N,L,Syms<:Tuple} = Syms.parameters[dim]
+#     A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+#     dimSymbols(A,2)  # (:x, :y)
+# """
+# dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where 
+# {S,T,N,L,Syms<:Tuple} = Syms.parameters[dim]
 
-"returns dimSymbols(,1)"
-rowSymbols(::SLArray{S,T,N,L,Syms}) where 
-{S,T,N,L,Syms<:Tuple} = Syms.parameters[1]
+# "returns dimSymbols(,1)"
+# rowSymbols(::SLArray{S,T,N,L,Syms}) where 
+# {S,T,N,L,Syms<:Tuple} = Syms.parameters[1]
 
-"returns dimSymbols(,2)"
-colSymbols(::SLArray{S,T,N,L,Syms}) where 
-{S,T,N,L,Syms<:Tuple} = Syms.parameters[2]
+# "returns dimSymbols(,2)"
+# colSymbols(::SLArray{S,T,N,L,Syms}) where 
+# {S,T,N,L,Syms<:Tuple} = Syms.parameters[2]
+
+symbols(::SLArray{S,T,N,L,Syms}) where 
+{rows,cols,S,T,N,L,Syms<:Tuple{rows,cols}} = rows,cols
+

--- a/src/slsliced.jl
+++ b/src/slsliced.jl
@@ -41,3 +41,25 @@ macro SLSliced(T,dims,syms)
       SLArray{Tuple{$dims...},$T,length($dims),prod($dims),Tuple{$syms...}}
   end
 end
+
+
+"""
+    dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where {Syms<:Tuple}
+
+Returns the labels of the `SLArray` associated with dimension `dim`.
+
+For example:
+
+    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    dimSymbols(A,2)  # (:x, :y)
+"""
+dimSymbols(::SLArray{S,T,N,L,Syms}, dim::Int) where 
+{S,T,N,L,Syms<:Tuple} = Syms.parameters[dim]
+
+"returns dimSymbols(,1)"
+rowSymbols(::SLArray{S,T,N,L,Syms}) where 
+{S,T,N,L,Syms<:Tuple} = Syms.parameters[1]
+
+"returns dimSymbols(,2)"
+colSymbols(::SLArray{S,T,N,L,Syms}) where 
+{S,T,N,L,Syms<:Tuple} = Syms.parameters[2]

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -88,3 +88,11 @@ end
     copy(t) # should be ok
     deepcopy(t) # should also be ok
 end
+
+@testset "accessing labels, i.e. symbols" begin
+    z = @LArray Float64 (2,2) (:a,:b,:c,:d)
+    ret = symbols(z)
+    @test ret == (:a,:b,:c,:d)
+    #ret2 = dimSymbols(z,1) # no method defined if Syms is not a tuple
+end
+

--- a/test/lsliced.jl
+++ b/test/lsliced.jl
@@ -75,3 +75,23 @@ end
     copy(t) # should be ok
     deepcopy(t) # should also be ok
 end
+
+@testset "accessing labels, i.e. symbols" begin
+    ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y)
+    A = ABC([1 2; 3 4; 5 6])
+    ret = symbols(A)
+    @test ret == Tuple{(:a,:b,:c),(:x,:y)}
+end
+
+@testset "accessing dimensions symbols of LSliced" begin
+    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    dim = 1
+    rows = dimSymbols(A,dim)
+    @test rows == (:a,:b,:c)
+    cols = dimSymbols(A,2)
+    @test cols == (:x,:y)
+    rows = rowSymbols(A)
+    @test rows == (:a,:b,:c)
+    cols = colSymbols(A)
+    @test cols == (:x,:y)
+end

--- a/test/lsliced.jl
+++ b/test/lsliced.jl
@@ -77,21 +77,25 @@ end
 end
 
 @testset "accessing labels, i.e. symbols" begin
-    ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y)
-    A = ABC([1 2; 3 4; 5 6])
-    ret = symbols(A)
-    @test ret == Tuple{(:a,:b,:c),(:x,:y)}
+    A2 = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+    ret = symbols(A2)
+    @test ret == ((:a, :b, :c), (:x, :y))
+    #
+    # higher dimensional still returns a tuple-Type object
+    A3 = @LSliced cat(A2,10*A2;dims = 3) (:a,:b,:c), (:x, :y), (:u,:v)
+    ret = symbols(A3)
+    @test ret == Tuple{(:a, :b, :c),(:x, :y),(:u, :v)}
 end
 
-@testset "accessing dimensions symbols of LSliced" begin
-    A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
-    dim = 1
-    rows = dimSymbols(A,dim)
-    @test rows == (:a,:b,:c)
-    cols = dimSymbols(A,2)
-    @test cols == (:x,:y)
-    rows = rowSymbols(A)
-    @test rows == (:a,:b,:c)
-    cols = colSymbols(A)
-    @test cols == (:x,:y)
-end
+# @testset "accessing dimensions symbols of LSliced" begin
+#     A = @LSliced [1 2; 3 4; 5 6] (:a,:b,:c), (:x, :y)
+#     dim = 1
+#     rows = dimSymbols(A,dim)
+#     @test rows == (:a,:b,:c)
+#     cols = dimSymbols(A,2)
+#     @test cols == (:x,:y)
+#     rows = rowSymbols(A)
+#     @test rows == (:a,:b,:c)
+#     cols = colSymbols(A)
+#     @test cols == (:x,:y)
+# end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -51,3 +51,9 @@ end
     @inferred(convert(NamedTuple, y))
     @inferred(collect(pairs(y)))
 end
+
+@testset "accessing labels, i.e. symbols" begin
+    z = SLVector(a=1, b=2, c=3)
+    ret = symbols(z)
+    @test ret == (:a,:b,:c)
+end

--- a/test/slsliced.jl
+++ b/test/slsliced.jl
@@ -34,3 +34,17 @@ using LabelledArrays, Test, StaticArrays
 
     @test @inferred(zero(b)) === ABC_int(zero(b))
 end
+
+@testset "accessing dimensions symbols of SLSliced" begin
+    ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y)
+    A = ABC([1 2; 3 4; 5 6])
+    rows = dimSymbols(A,1)
+    @test rows == (:a,:b,:c)
+    cols = dimSymbols(A,2)
+    @test cols == (:x,:y)
+    rows = rowSymbols(A)
+    @test rows == (:a,:b,:c)
+    cols = colSymbols(A)
+    @test cols == (:x,:y)
+end
+

--- a/test/slsliced.jl
+++ b/test/slsliced.jl
@@ -38,13 +38,7 @@ end
 @testset "accessing dimensions symbols of SLSliced" begin
     ABC = @SLSliced (3,2) (:a,:b,:c), (:x, :y)
     A = ABC([1 2; 3 4; 5 6])
-    rows = dimSymbols(A,1)
-    @test rows == (:a,:b,:c)
-    cols = dimSymbols(A,2)
-    @test cols == (:x,:y)
-    rows = rowSymbols(A)
-    @test rows == (:a,:b,:c)
-    cols = colSymbols(A)
-    @test cols == (:x,:y)
+    ret = symbols(A)
+    @test ret == ((:a,:b,:c),(:x,:y))
 end
 


### PR DESCRIPTION
implements #50 

Function `symbols` working on both `LArray` and `SLArray` return in a tuple of Symbols. For more dimensional names (providing a tuple of tuples to `LSliced`) it returns a `Tuple` object that is hard to handle. Therefore, I also implemented function `dimSymbols` that accesses the entry in this tuple in field `parameters`. Is there a better way?