### PR TITLE
Add explicit indices handling via NamedTuple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ julia> y.g
  2.5
  3.0
  5.0
+
+julia> Arr = @SLArray (2, 2) (a = (2, :), b = 3);
+julia> z = Arr(1, 2, 3, 4);
+julia> z.a
+2-element view(::StaticArrays.SArray{Tuple{2,2},Int64,2,4}, 2, :) with eltype Int64:
+ 2
+ 4
 ```
 
 ## LArrays
@@ -142,6 +149,11 @@ julia> z.b
 2-element view(::Array{Float64,1}, 2:3) with eltype Float64:
  2.0
  3.0
+julia> z = @LArray [1 2; 3 4] (a = (2, :), b = 2:3);
+julia> z.a
+2-element view(::Array{Int64,2}, 2, :) with eltype Int64:
+ 3
+ 4
 ```
 
 The labels of LArray and SLArray can be accessed 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ julia> B2 = SLArray(B; c=30 )
  2   4
 ```
 
+One can also specify the indices directly.
+```julia
+julia> EFG = @SLArray (2,2) (e=1:3, f=4, g=2:4);
+julia> y = EFG(1.0,2.5,3.0,5.0)
+2×2 SLArray{Tuple{2,2},Float64,2,4,(e = 1:3, f = 4, g = 2:4)}:
+ 1.0  3.0
+ 2.5  5.0
+
+julia> y.g
+3-element view(reshape(::StaticArrays.SArray{Tuple{2,2},Float64,2,4}, 4), 2:4) with eltype Float64:
+ 2.5
+ 3.0
+ 5.0
+```
+
 ## LArrays
 
 The `LArrays`s are fully mutable arrays with labels. There is no performance
@@ -118,6 +133,15 @@ julia> LArray((2,2); a=1, b=2, c=3, d=4) # need to specify size as first argumen
 2×2 LArray{Int64,2,(:a, :b, :c, :d)}:
  1  3
  2  4
+```
+
+One can also specify the indices directly.
+```julia
+julia> z = @LArray [1.,2.,3.] (a = 1:2, b = 2:3);
+julia> z.b
+2-element view(::Array{Float64,1}, 2:3) with eltype Float64:
+ 2.0
+ 3.0
 ```
 
 The labels of LArray and SLArray can be accessed 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 1.1
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -24,24 +24,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"LabelledArrays\"); Pkg.build(\"LabelledArrays\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"LabelledArrays\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -139,6 +139,7 @@ For example:
 
     a = @LArray Float64 (2,2) (:a,:b,:c,:d)
     b = @LArray [1,2,3] (:a,:b,:c)
+    c = @LArray [1,2,3] (a=1:2,b=2:3)
 """
 macro LArray(vals,syms)
   vals = esc(vals)

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -61,7 +61,7 @@ end
   syms = symnames(typeof(x))
   if syms isa NamedTuple
     idxs = syms[s]
-    return @views x.__x[idxs]
+    return idxs isa Tuple ? @views(x.__x[idxs...]) : @views(x.__x[idxs])
   else
     return getindex(x,Val(s))
   end
@@ -139,7 +139,8 @@ For example:
 
     a = @LArray Float64 (2,2) (:a,:b,:c,:d)
     b = @LArray [1,2,3] (:a,:b,:c)
-    c = @LArray [1,2,3] (a=1:2,b=2:3)
+    c = @LArray [1,2,3] (a=1:2, b=2:3)
+    d = @LArray [1 2; 3 4] (a=(2, :), b=2:3)
 """
 macro LArray(vals,syms)
   vals = esc(vals)

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -189,7 +189,7 @@ For example:
     z = @LVector Float64 (:a,:b,:c,:d)
     symbols(z)  # NTuple{4,Symbol} == (:a, :b, :c, :d)
 """
-symbols(::LArray{T,N,D,Syms}) where {T,N,D,Syms} = Syms
+symbols(::LArray{T,N,D,Syms}) where {T,N,D,Syms} = Syms isa NamedTuple ? keys(Syms) : Syms
 
 
 # copy constructors

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -122,11 +122,14 @@ x.a == 1.0
 x.b == 2.5
 x.c == x[3]
 x.d == x[2,2]
+EFG = @SLArray (2,2) (e=1:3, f=4, g=2:4)
+y = EFG(1.0,2.5,3.0,5.0)
 ```
 
 """
 macro SLArray(dims,syms)
   dims isa Expr && (dims = dims.args)
+  syms = esc(syms)
   quote
     SLArray{Tuple{$dims...},$syms}
   end
@@ -134,6 +137,7 @@ end
 
 macro SLArray(T,dims,syms)
   dims isa Expr && (dims = dims.args)
+  syms = esc(syms)
   quote
     SLArray{Tuple{$dims...},$T,$(length(dims)),$(prod(dims)),$syms}
   end

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -189,4 +189,4 @@ For example:
     z = SLVector(a=1, b=2, c=3)
     symbols(z)  # Tuple{Symbol,Symbol,Symbol} == (:a, :b, :c)
 """
-symbols(::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} = Syms
+symbols(::SLArray{S,T,N,L,Syms}) where {S,T,N,L,Syms} = Syms isa NamedTuple ? keys(Syms) : Syms

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -82,7 +82,7 @@ end
   syms = symnames(typeof(x))
   if syms isa NamedTuple
     idxs = syms[s]
-    return @views x.__x[idxs]
+    return idxs isa Tuple ? @views(x.__x[idxs...]) : @views(x.__x[idxs])
   else
     return getindex(x,Val(s))
   end
@@ -124,6 +124,7 @@ x.c == x[3]
 x.d == x[2,2]
 EFG = @SLArray (2,2) (e=1:3, f=4, g=2:4)
 y = EFG(1.0,2.5,3.0,5.0)
+EFG = @SLArray (2,2) (e=(2, :), f=4, g=2:4)
 ```
 
 """

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -120,4 +120,5 @@ end
   z = @LArray [1.,2.] (a = 1, b = 2)
   @test z.a === 1.0
   @test z.b === 2.0
+  @test symbols(z) === (:a, :b)
 end

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -121,4 +121,6 @@ end
   @test z.a === 1.0
   @test z.b === 2.0
   @test symbols(z) === (:a, :b)
+  z = @LArray [1 2; 3 4] (a = (2, :), b = 2:3)
+  @test z.a == [3, 4]
 end

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -106,8 +106,18 @@ end
     @test zs[[:c,:a]] == [3.,1.]
 end
 
-
-
-
-
-
+@testset "Explicit indices" begin
+  z = @LArray [1.,2.,3.] (a = 1:2, b = 3)
+  @test z.a isa SubArray
+  @test z.a == [1, 2.]
+  z.a = [100, 200.]
+  @test z.a == [100, 200.]
+  @test z.b === 3.
+  z.b = 1000.
+  @test z.b === 1000.
+  z = @LArray [1.,2.,3.] (a = 1:2, b = 1:3)
+  @test z.b === view(z.__x, 1:3)
+  z = @LArray [1.,2.] (a = 1, b = 2)
+  @test z.a === 1.0
+  @test z.b === 2.0
+end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -72,4 +72,7 @@ end
   @test z.a === 1
   @test z.b === 2
   @test symbols(z) === (:a, :b)
+  Arr = @SLArray (2, 2) (a = (2, :), b = 3)
+  z = Arr(1, 2, 3, 4)
+  @test z.a == [2, 4]
 end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -57,3 +57,18 @@ end
     ret = symbols(z)
     @test ret == (:a,:b,:c)
 end
+
+@testset "Explicit indices" begin
+  Arr = @SLVector (a = 1:2, b = 3)
+  z = Arr(1.,2.,3.)
+  @test z.a isa SubArray
+  @test z.a == [1, 2.]
+  @test z.b === 3.
+  Arr = @SLVector (a = 1:2, b = 2:3)
+  z = Arr(1.,2.,3.)
+  @test z.b == [2, 3.]
+  Arr = @SLVector (a = 1, b = 2)
+  z = Arr(1, 2)
+  @test z.a === 1
+  @test z.b === 2
+end

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -71,4 +71,5 @@ end
   z = Arr(1, 2)
   @test z.a === 1
   @test z.b === 2
+  @test symbols(z) === (:a, :b)
 end


### PR DESCRIPTION
```julia
julia> EFG = @SLArray (2,2) (e=1:3, f=4, g=2:4);

julia> y = EFG(1.0,2.5,3.0,5.0)
2×2 SLArray{Tuple{2,2},Float64,2,4,(e = 1:3, f = 4, g = 2:4)}:
 1.0  3.0
 2.5  5.0

julia> y.g
3-element view(reshape(::StaticArrays.SArray{Tuple{2,2},Float64,2,4}, 4), 2:4) with eltype Float64:
 2.5
 3.0
 5.0

julia> z = @LArray [1.,2.,3.] (a = 1:2, b = 2:3);

julia> z.b
2-element view(::Array{Float64,1}, 2:3) with eltype Float64:
 2.0
 3.0
```

is now possible.

CC: @jessebett